### PR TITLE
Applied Energistics 2 support

### DIFF
--- a/src/api/java/appeng/api/AEApi.java
+++ b/src/api/java/appeng/api/AEApi.java
@@ -1,0 +1,61 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api;
+
+/**
+ * 
+ * Entry point for api.
+ * 
+ * Available IMCs:
+ * 
+ */
+public class AEApi
+{
+
+	static private IAppEngApi api = null;
+
+	/**
+	 * API Entry Point.
+	 * 
+	 * @return the {@link IAppEngApi} or null if the instance could not be retrieved
+	 */
+	public static IAppEngApi instance()
+	{
+		if ( api == null )
+		{
+			try
+			{
+				Class c = Class.forName( "appeng.core.Api" );
+				api = (IAppEngApi) c.getField( "instance" ).get( c );
+			}
+			catch (Throwable e)
+			{
+				return null;
+			}
+		}
+
+		return api;
+	}
+
+}

--- a/src/api/java/appeng/api/IAppEngApi.java
+++ b/src/api/java/appeng/api/IAppEngApi.java
@@ -1,0 +1,94 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api;
+
+import appeng.api.definitions.Blocks;
+import appeng.api.definitions.Items;
+import appeng.api.definitions.Materials;
+import appeng.api.definitions.Parts;
+import appeng.api.exceptions.FailedConnection;
+import appeng.api.features.IRegistryContainer;
+import appeng.api.networking.IGridBlock;
+import appeng.api.networking.IGridConnection;
+import appeng.api.networking.IGridHost;
+import appeng.api.networking.IGridNode;
+import appeng.api.parts.IPartHelper;
+import appeng.api.storage.IStorageHelper;
+
+public interface IAppEngApi
+{
+
+	/**
+	 * @return Registry Container for the numerous registries in AE2.
+	 */
+	IRegistryContainer registries();
+
+	/**
+	 * @return helper for working with storage data types.
+	 */
+	IStorageHelper storage();
+
+	/**
+	 * @return helper for working with grids, and buses.
+	 */
+	IPartHelper partHelper();
+
+	/**
+	 * @return an accessible list of all of AE's Items
+	 */
+	Items items();
+
+	/**
+	 * @return an accessible list of all of AE's materials; materials are items
+	 */
+	Materials materials();
+
+	/**
+	 * @return an accessible list of all of AE's blocks
+	 */
+	Blocks blocks();
+
+	/**
+	 * @return an accessible list of all of AE's parts, parts are items
+	 */
+	Parts parts();
+
+	/**
+	 * create a grid node for your {@link IGridHost}
+	 * 
+	 * @param block grid block
+	 * @return grid node of block
+	 */
+	IGridNode createGridNode(IGridBlock block);
+
+	/**
+	 * create a connection between two {@link IGridNode}
+	 * 
+	 * @param a to be connected gridnode
+	 * @param b to be connected gridnode
+	 * @throws FailedConnection
+	 */
+	IGridConnection createGridConnection(IGridNode a, IGridNode b) throws FailedConnection;
+
+}

--- a/src/api/java/appeng/api/config/AccessRestriction.java
+++ b/src/api/java/appeng/api/config/AccessRestriction.java
@@ -1,0 +1,71 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.config;
+
+public enum AccessRestriction
+{
+	NO_ACCESS(0), READ(1), WRITE(2), READ_WRITE(3);
+
+	private final int permissionBit;
+
+	private AccessRestriction(int v) {
+		permissionBit = v;
+	}
+
+	public boolean hasPermission(AccessRestriction ar)
+	{
+		return (permissionBit & ar.permissionBit) == ar.permissionBit;
+	}
+
+	public AccessRestriction restrictPermissions(AccessRestriction ar)
+	{
+		return getPermByBit( permissionBit & ar.permissionBit);
+	}
+
+	public AccessRestriction addPermissions(AccessRestriction ar)
+	{
+		return getPermByBit( permissionBit | ar.permissionBit);
+	}
+
+	public AccessRestriction removePermissions(AccessRestriction ar)
+	{
+		return getPermByBit( permissionBit & (~ar.permissionBit) );
+	}
+
+	private AccessRestriction getPermByBit(int bit)
+	{
+		switch (bit)
+		{
+		default:
+		case 0:
+			return NO_ACCESS;
+		case 1:
+			return READ;
+		case 2:
+			return WRITE;
+		case 3:
+			return READ_WRITE;
+		}
+	}
+}

--- a/src/api/java/appeng/api/config/Actionable.java
+++ b/src/api/java/appeng/api/config/Actionable.java
@@ -1,0 +1,37 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.config;
+
+public enum Actionable
+{
+	/**
+	 * Perform the intended action.
+	 */
+	MODULATE,
+
+	/**
+	 * Pretend to perform the action.
+	 */
+	SIMULATE
+}

--- a/src/api/java/appeng/api/config/FuzzyMode.java
+++ b/src/api/java/appeng/api/config/FuzzyMode.java
@@ -1,0 +1,44 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.config;
+
+public enum FuzzyMode
+{
+	// Note that percentage damaged, is the inverse of percentage durability.
+	IGNORE_ALL(-1), PERCENT_99(0), PERCENT_75(25), PERCENT_50(50), PERCENT_25(75);
+
+	final public float breakPoint;
+	final public float percentage;
+
+	private FuzzyMode(float p) {
+		percentage = p;
+		breakPoint = p / 100.0f;
+	}
+
+	public int calculateBreakPoint(int maxDamage)
+	{
+		return (int) ((percentage * maxDamage) / 100.0f);
+	}
+
+}

--- a/src/api/java/appeng/api/config/PowerMultiplier.java
+++ b/src/api/java/appeng/api/config/PowerMultiplier.java
@@ -1,0 +1,44 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.config;
+
+public enum PowerMultiplier
+{
+	ONE, CONFIG;
+
+	/**
+	 * please do not edit this value, it is set when AE loads its config files.
+	 */
+	public double multiplier = 1.0;
+
+	public double multiply(double in)
+	{
+		return in * multiplier;
+	}
+
+	public double divide(double in)
+	{
+		return in / multiplier;
+	}
+}

--- a/src/api/java/appeng/api/config/SecurityPermissions.java
+++ b/src/api/java/appeng/api/config/SecurityPermissions.java
@@ -1,0 +1,70 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.config;
+
+/**
+ * Represent the security systems basic permissions, these are not for anti-griefing, they are part of the mod as a
+ * gameplay feature.
+ */
+public enum SecurityPermissions
+{
+	/**
+	 * required to insert items into the network via terminal ( also used for machines based on the owner of the
+	 * network, which is determined by its Security Block. )
+	 */
+	INJECT,
+
+	/**
+	 * required to extract items from the network via terminal ( also used for machines based on the owner of the
+	 * network, which is determined by its Security Block. )
+	 */
+	EXTRACT,
+
+	/**
+	 * required to request crafting from the network via terminal.
+	 */
+	CRAFT,
+
+	/**
+	 * required to modify automation, and make modifications to the networks physical layout.
+	 */
+	BUILD,
+
+	/**
+	 * required to modify the security blocks settings.
+	 */
+	SECURITY;
+
+	final private String unlocalizedName = "gui.appliedenergistics2.security." + name().toLowerCase();
+
+	public String getUnlocalizedName()
+	{
+		return unlocalizedName + ".name";
+	}
+
+	public String getUnlocalizedTip()
+	{
+		return unlocalizedName + ".tip";
+	}
+}

--- a/src/api/java/appeng/api/config/TunnelType.java
+++ b/src/api/java/appeng/api/config/TunnelType.java
@@ -1,0 +1,38 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.config;
+
+public enum TunnelType
+{
+	ME, // Network Tunnel
+	BC_POWER, // MJ Tunnel
+	IC2_POWER, // EU Tunnel
+	RF_POWER, // RF Tunnel
+	REDSTONE, // Redstone Tunnel
+	FLUID, // Fluid Tunnel
+	ITEM, // Item Tunnel
+	LIGHT, // Light Tunnel
+	BUNDLED_REDSTONE, // Bundled Redstone Tunnel
+	COMPUTER_MESSAGE // Computer Message Tunnel
+}

--- a/src/api/java/appeng/api/definitions/Blocks.java
+++ b/src/api/java/appeng/api/definitions/Blocks.java
@@ -1,0 +1,112 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.definitions;
+
+import appeng.api.util.AEItemDefinition;
+
+public class Blocks
+{
+
+	/*
+	 * World Gen
+	 */
+	public AEItemDefinition blockQuartzOre;
+	public AEItemDefinition blockQuartzOreCharged;
+	public AEItemDefinition blockMatrixFrame;
+
+	/*
+	 * Decorative
+	 */
+	public AEItemDefinition blockQuartz;
+	public AEItemDefinition blockQuartzPillar;
+	public AEItemDefinition blockQuartzChiseled;
+	public AEItemDefinition blockQuartzGlass;
+	public AEItemDefinition blockQuartzVibrantGlass;
+	public AEItemDefinition blockQuartzTorch;
+	public AEItemDefinition blockFluix;
+	public AEItemDefinition blockSkyStone;
+	public AEItemDefinition blockSkyChest;
+	public AEItemDefinition blockSkyCompass;
+
+	/*
+	 * Misc
+	 */
+	public AEItemDefinition blockGrindStone;
+	public AEItemDefinition blockCrankHandle;
+	public AEItemDefinition blockInscriber;
+	public AEItemDefinition blockWireless;
+	public AEItemDefinition blockCharger;
+	public AEItemDefinition blockTinyTNT;
+	public AEItemDefinition blockSecurity;
+
+	/*
+	 * Quantum Network Bridge
+	 */
+	public AEItemDefinition blockQuantumRing;
+	public AEItemDefinition blockQuantumLink;
+
+	/*
+	 * Spatial IO
+	 */
+	public AEItemDefinition blockSpatialPylon;
+	public AEItemDefinition blockSpatialIOPort;
+
+	/*
+	 * Bus / Cables
+	 */
+	public AEItemDefinition blockMultiPart;
+
+	/*
+	 * Machines
+	 */
+	public AEItemDefinition blockController;
+	public AEItemDefinition blockDrive;
+	public AEItemDefinition blockChest;
+	public AEItemDefinition blockInterface;
+	public AEItemDefinition blockCellWorkbench;
+	public AEItemDefinition blockIOPort;
+	public AEItemDefinition blockCondenser;
+	public AEItemDefinition blockEnergyAcceptor;
+	public AEItemDefinition blockVibrationChamber;
+	public AEItemDefinition blockQuartzGrowthAccelerator;
+
+	public AEItemDefinition blockEnergyCell;
+	public AEItemDefinition blockEnergyCellDense;
+	public AEItemDefinition blockEnergyCellCreative;
+
+	// rv1
+	public AEItemDefinition blockCraftingUnit;
+	public AEItemDefinition blockCraftingAccelerator;
+	public AEItemDefinition blockCraftingStorage1k;
+	public AEItemDefinition blockCraftingStorage4k;
+	public AEItemDefinition blockCraftingStorage16k;
+	public AEItemDefinition blockCraftingStorage64k;
+	public AEItemDefinition blockCraftingMonitor;
+
+	public AEItemDefinition blockMolecularAssembler;
+
+	public AEItemDefinition blockLightDetector;
+	public AEItemDefinition blockPaint;
+
+}

--- a/src/api/java/appeng/api/definitions/Items.java
+++ b/src/api/java/appeng/api/definitions/Items.java
@@ -1,0 +1,77 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.definitions;
+
+import appeng.api.util.AEColoredItemDefinition;
+import appeng.api.util.AEItemDefinition;
+
+public class Items
+{
+
+	public AEItemDefinition itemCertusQuartzAxe;
+	public AEItemDefinition itemCertusQuartzHoe;
+	public AEItemDefinition itemCertusQuartzShovel;
+	public AEItemDefinition itemCertusQuartzPick;
+	public AEItemDefinition itemCertusQuartzSword;
+	public AEItemDefinition itemCertusQuartzWrench;
+	public AEItemDefinition itemCertusQuartzKnife;
+
+	public AEItemDefinition itemNetherQuartzAxe;
+	public AEItemDefinition itemNetherQuartzHoe;
+	public AEItemDefinition itemNetherQuartzShovel;
+	public AEItemDefinition itemNetherQuartzPick;
+	public AEItemDefinition itemNetherQuartzSword;
+	public AEItemDefinition itemNetherQuartzWrench;
+	public AEItemDefinition itemNetherQuartzKnife;
+
+	public AEItemDefinition itemEntropyManipulator;
+	public AEItemDefinition itemWirelessTerminal;
+	public AEItemDefinition itemBiometricCard;
+	public AEItemDefinition itemChargedStaff;
+	public AEItemDefinition itemMassCannon;
+	public AEItemDefinition itemMemoryCard;
+	public AEItemDefinition itemNetworkTool;
+	public AEItemDefinition itemPortableCell;
+
+	public AEItemDefinition itemCellCreative;
+	public AEItemDefinition itemViewCell;
+
+	public AEItemDefinition itemCell1k;
+	public AEItemDefinition itemCell4k;
+	public AEItemDefinition itemCell16k;
+	public AEItemDefinition itemCell64k;
+
+	public AEItemDefinition itemSpatialCell2;
+	public AEItemDefinition itemSpatialCell16;
+	public AEItemDefinition itemSpatialCell128;
+
+	public AEItemDefinition itemFacade;
+	public AEItemDefinition itemCrystalSeed;
+
+	// rv1
+	public AEItemDefinition itemEncodedPattern;
+	public AEItemDefinition itemColorApplicator;
+	public AEColoredItemDefinition itemPaintBall;
+	public AEColoredItemDefinition itemLumenPaintBall;
+}

--- a/src/api/java/appeng/api/definitions/Materials.java
+++ b/src/api/java/appeng/api/definitions/Materials.java
@@ -1,0 +1,103 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.definitions;
+
+import appeng.api.util.AEItemDefinition;
+
+public class Materials
+{
+
+	public AEItemDefinition materialCell2SpatialPart;
+	public AEItemDefinition materialCell16SpatialPart;
+	public AEItemDefinition materialCell128SpatialPart;
+
+	public AEItemDefinition materialSilicon;
+	public AEItemDefinition materialSkyDust;
+
+	public AEItemDefinition materialCalcProcessorPress;
+	public AEItemDefinition materialEngProcessorPress;
+	public AEItemDefinition materialLogicProcessorPress;
+
+	public AEItemDefinition materialCalcProcessorPrint;
+	public AEItemDefinition materialEngProcessorPrint;
+	public AEItemDefinition materialLogicProcessorPrint;
+
+	public AEItemDefinition materialSiliconPress;
+	public AEItemDefinition materialSiliconPrint;
+
+	public AEItemDefinition materialNamePress;
+
+	public AEItemDefinition materialLogicProcessor;
+	public AEItemDefinition materialCalcProcessor;
+	public AEItemDefinition materialEngProcessor;
+
+	public AEItemDefinition materialBasicCard;
+	public AEItemDefinition materialAdvCard;
+
+	public AEItemDefinition materialPurifiedCertusQuartzCrystal;
+	public AEItemDefinition materialPurifiedNetherQuartzCrystal;
+	public AEItemDefinition materialPurifiedFluixCrystal;
+
+	public AEItemDefinition materialCell1kPart;
+	public AEItemDefinition materialCell4kPart;
+	public AEItemDefinition materialCell16kPart;
+	public AEItemDefinition materialCell64kPart;
+	public AEItemDefinition materialEmptyStorageCell;
+
+	public AEItemDefinition materialCardRedstone;
+	public AEItemDefinition materialCardSpeed;
+	public AEItemDefinition materialCardCapacity;
+	public AEItemDefinition materialCardFuzzy;
+	public AEItemDefinition materialCardInverter;
+	public AEItemDefinition materialCardCrafting;
+
+	public AEItemDefinition materialEnderDust;
+	public AEItemDefinition materialFlour;
+	public AEItemDefinition materialGoldDust;
+	public AEItemDefinition materialIronDust;
+	public AEItemDefinition materialFluixDust;
+	public AEItemDefinition materialCertusQuartzDust;
+	public AEItemDefinition materialNetherQuartzDust;
+
+	public AEItemDefinition materialMatterBall;
+	public AEItemDefinition materialIronNugget;
+
+	public AEItemDefinition materialCertusQuartzCrystal;
+	public AEItemDefinition materialCertusQuartzCrystalCharged;
+	public AEItemDefinition materialFluixCrystal;
+	public AEItemDefinition materialFluixPearl;
+
+	public AEItemDefinition materialWoodenGear;
+
+	public AEItemDefinition materialWireless;
+	public AEItemDefinition materialWirelessBooster;
+
+	public AEItemDefinition materialAnnihilationCore;
+	public AEItemDefinition materialFormationCore;
+
+	public AEItemDefinition materialSingularity;
+	public AEItemDefinition materialQESingularity;
+	public AEItemDefinition materialBlankPattern;
+
+}

--- a/src/api/java/appeng/api/definitions/Parts.java
+++ b/src/api/java/appeng/api/definitions/Parts.java
@@ -1,0 +1,76 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.definitions;
+
+import appeng.api.util.AEColoredItemDefinition;
+import appeng.api.util.AEItemDefinition;
+
+public class Parts
+{
+
+	public AEColoredItemDefinition partCableSmart;
+	public AEColoredItemDefinition partCableCovered;
+	public AEColoredItemDefinition partCableGlass;
+	public AEColoredItemDefinition partCableDense;
+
+	public AEColoredItemDefinition partLumenCableSmart;
+	public AEColoredItemDefinition partLumenCableCovered;
+	public AEColoredItemDefinition partLumenCableGlass;
+	public AEColoredItemDefinition partLumenCableDense;
+
+	public AEItemDefinition partQuartzFiber;
+	public AEItemDefinition partToggleBus;
+	public AEItemDefinition partInvertedToggleBus;
+
+	public AEItemDefinition partStorageBus;
+	public AEItemDefinition partImportBus;
+	public AEItemDefinition partExportBus;
+	public AEItemDefinition partInterface;
+
+	public AEItemDefinition partLevelEmitter;
+
+	public AEItemDefinition partAnnihilationPlane;
+	public AEItemDefinition partFormationPlane;
+
+	public AEItemDefinition partP2PTunnelME;
+	public AEItemDefinition partP2PTunnelRedstone;
+	public AEItemDefinition partP2PTunnelItems;
+	public AEItemDefinition partP2PTunnelLiquids;
+	public AEItemDefinition partP2PTunnelMJ;
+	public AEItemDefinition partP2PTunnelEU;
+	public AEItemDefinition partP2PTunnelRF;
+	public AEItemDefinition partP2PTunnelLight;
+
+	public AEItemDefinition partCableAnchor;
+	public AEItemDefinition partMonitor;
+	public AEItemDefinition partSemiDarkMonitor;
+	public AEItemDefinition partDarkMonitor;
+
+	public AEItemDefinition partInterfaceTerminal;
+	public AEItemDefinition partPatternTerminal;
+	public AEItemDefinition partCraftingTerminal;
+	public AEItemDefinition partTerminal;
+	public AEItemDefinition partStorageMonitor;
+	public AEItemDefinition partConversionMonitor;
+}

--- a/src/api/java/appeng/api/exceptions/FailedConnection.java
+++ b/src/api/java/appeng/api/exceptions/FailedConnection.java
@@ -1,0 +1,33 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.exceptions;
+
+public class FailedConnection extends Exception
+{
+
+	private static final long serialVersionUID = -2544208090248293753L;
+
+	public FailedConnection() {
+	}
+}

--- a/src/api/java/appeng/api/exceptions/MissingIngredientError.java
+++ b/src/api/java/appeng/api/exceptions/MissingIngredientError.java
@@ -1,0 +1,34 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.exceptions;
+
+public class MissingIngredientError extends Exception {
+
+	private static final long serialVersionUID = -998858343831371697L;
+
+	public MissingIngredientError(String n) {
+		super( n );
+	}
+
+}

--- a/src/api/java/appeng/api/exceptions/RecipeError.java
+++ b/src/api/java/appeng/api/exceptions/RecipeError.java
@@ -1,0 +1,35 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.exceptions;
+
+public class RecipeError extends Exception
+{
+
+	private static final long serialVersionUID = -6602870588617670262L;
+
+	public RecipeError(String n) {
+		super( n );
+	}
+
+}

--- a/src/api/java/appeng/api/exceptions/RegistrationError.java
+++ b/src/api/java/appeng/api/exceptions/RegistrationError.java
@@ -1,0 +1,35 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.exceptions;
+
+public class RegistrationError extends Exception
+{
+
+	private static final long serialVersionUID = -6602870588617670263L;
+
+	public RegistrationError(String n) {
+		super( n );
+	}
+
+}

--- a/src/api/java/appeng/api/features/IGrinderEntry.java
+++ b/src/api/java/appeng/api/features/IGrinderEntry.java
@@ -1,0 +1,119 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.features;
+
+import net.minecraft.item.ItemStack;
+
+/**
+ * Registration Records for {@link IGrinderRegistry}
+ */
+public interface IGrinderEntry
+{
+
+	/**
+	 * the current input
+	 * 
+	 * @return input that the grinder will accept.
+	 */
+	public ItemStack getInput();
+
+	/**
+	 * lets you change the grinder recipe by changing its input.
+	 * 
+	 * @param input input item
+	 */
+	public void setInput(ItemStack input);
+
+	/**
+	 * gets the current output
+	 * 
+	 * @return output that the grinder will produce
+	 */
+	public ItemStack getOutput();
+
+	/**
+	 * gets the current output
+	 * 
+	 * @return output that the grinder will produce
+	 */
+	public ItemStack getOptionalOutput();
+
+	/**
+	 * gets the current output
+	 * 
+	 * @return output that the grinder will produce
+	 */
+	public ItemStack getSecondOptionalOutput();
+
+	/**
+	 * allows you to change the output.
+	 * 
+	 * @param output output item
+	 */
+	public void setOutput(ItemStack output);
+
+	/**
+	 * stack, and 0.0-1.0 chance that it will be generated.
+	 * 
+	 * @param output output item
+	 * @param chance generation chance
+	 */
+	public void setOptionalOutput(ItemStack output, float chance);
+
+	/**
+	 * 0.0 - 1.0 the chance that the optional output will be generated.
+	 * 
+	 * @return chance of optional output
+	 */
+	public float getOptionalChance();
+
+	/**
+	 * stack, and 0.0-1.0 chance that it will be generated.
+	 * 
+	 * @param output second optional output item
+	 * @param chance second optional output chance
+	 */
+	public void setSecondOptionalOutput(ItemStack output, float chance);
+
+	/**
+	 * 0.0 - 1.0 the chance that the optional output will be generated.
+	 * 
+	 * @return second optional output chance
+	 */
+	public float getSecondOptionalChance();
+
+	/**
+	 * Energy cost, in turns.
+	 * 
+	 * @return number of turns it takes to produce the output from the input.
+	 */
+	public int getEnergyCost();
+
+	/**
+	 * Allows you to adjust the number of turns
+	 * 
+	 * @param c number of turns to produce output.
+	 */
+	public void setEnergyCost(int c);
+}

--- a/src/api/java/appeng/api/features/IGrinderRegistry.java
+++ b/src/api/java/appeng/api/features/IGrinderRegistry.java
@@ -1,0 +1,84 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.features;
+
+import net.minecraft.item.ItemStack;
+
+import java.util.List;
+
+/**
+ * Lets you manipulate Grinder Recipes, by adding or editing existing ones.
+ */
+public interface IGrinderRegistry
+{
+
+	/**
+	 * Current list of registered recipes, you can modify this if you want too.
+	 * 
+	 * @return currentlyRegisteredRecipes
+	 */
+	public List<IGrinderEntry> getRecipes();
+
+	/**
+	 * add a new recipe the easy way, in &#8594; out, how many turns., duplicates will not be added.
+	 * 
+	 * @param in input
+	 * @param out output
+	 * @param turns amount of turns to turn the input into the output
+	 */
+	public void addRecipe(ItemStack in, ItemStack out, int turns);
+
+	/**
+	 * add a new recipe with optional outputs, duplicates will not be added.
+	 * 
+	 * @param in input
+	 * @param out output
+	 * @param optional optional output
+	 * @param chance chance to get the optional output within 0.0 - 1.0
+	 * @param turns amount of turns to turn the input into the outputs
+	 */
+	void addRecipe(ItemStack in, ItemStack out, ItemStack optional, float chance, int turns);
+
+	/**
+	 * add a new recipe with optional outputs, duplicates will not be added.
+	 * 
+	 * @param in input
+	 * @param out output
+	 * @param optional optional output
+	 * @param chance chance to get the optional output within 0.0 - 1.0
+	 * @param optional2 second optional output
+	 * @param chance2 chance to get the second optional output within 0.0 - 1.0
+	 * @param turns amount of turns to turn the input into the outputs
+	 */
+	void addRecipe(ItemStack in, ItemStack out, ItemStack optional, float chance, ItemStack optional2, float chance2, int turns);
+
+	/**
+	 * Searches for a recipe for a given input, and returns it.
+	 * 
+	 * @param input input
+	 * @return identified recipe or null
+	 */
+	public IGrinderEntry getRecipeForInput(ItemStack input);
+
+}

--- a/src/api/java/appeng/api/features/IItemComparison.java
+++ b/src/api/java/appeng/api/features/IItemComparison.java
@@ -1,0 +1,33 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.features;
+
+public interface IItemComparison
+{
+
+	public boolean sameAsPrecise(IItemComparison comp);
+
+	public boolean sameAsFuzzy(IItemComparison comp);
+
+}

--- a/src/api/java/appeng/api/features/IItemComparisonProvider.java
+++ b/src/api/java/appeng/api/features/IItemComparisonProvider.java
@@ -1,0 +1,53 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.features;
+
+import net.minecraft.item.ItemStack;
+
+/**
+ * Provider for special comparisons. when an item is encountered AE Will request
+ * if the comparison function handles the item, by trying to request a
+ * IItemComparison class.
+ */
+public interface IItemComparisonProvider
+{
+
+	/**
+	 * should return a new IItemComparison, or return null if it doesn't handle
+	 * the supplied item.
+	 * 
+	 * @param is item
+	 * @return IItemComparison, or null
+	 */
+	IItemComparison getComparison(ItemStack is);
+
+	/**
+	 * Simple test for support ( AE generally skips this and calls the above function. )
+	 * 
+	 * @param stack item
+	 * @return true, if getComparison will return a valid IItemComparison Object
+	 */
+	public boolean canHandle(ItemStack stack);
+
+}

--- a/src/api/java/appeng/api/features/ILocatableRegistry.java
+++ b/src/api/java/appeng/api/features/ILocatableRegistry.java
@@ -1,0 +1,41 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.features;
+
+/**
+ * A Registry for locatable items, works based on serial numbers.
+ */
+public interface ILocatableRegistry
+{
+
+	/**
+	 * Attempts to find the object with the serial specified, if it can it
+	 * returns the object.
+	 * 
+	 * @param serial serial
+	 * @return requestedObject, or null
+	 */
+	public abstract Object findLocatableBySerial(long serial);
+
+}

--- a/src/api/java/appeng/api/features/IMatterCannonAmmoRegistry.java
+++ b/src/api/java/appeng/api/features/IMatterCannonAmmoRegistry.java
@@ -1,0 +1,47 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.features;
+
+import net.minecraft.item.ItemStack;
+
+public interface IMatterCannonAmmoRegistry
+{
+
+	/**
+	 * register a new ammo, generally speaking this is based off of atomic weight to make it easier to guess at
+	 * 
+	 * @param ammo new ammo
+	 * @param weight atomic weight
+	 */
+	void registerAmmo(ItemStack ammo, double weight);
+
+	/**
+	 * get the penetration value for a particular ammo, 0 indicates a non-ammo.
+	 * 
+	 * @param is ammo
+	 * @return 0 or a valid penetration value.
+	 */
+	float getPenetration(ItemStack is);
+
+}

--- a/src/api/java/appeng/api/features/INetworkEncodable.java
+++ b/src/api/java/appeng/api/features/INetworkEncodable.java
@@ -1,0 +1,50 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.features;
+
+import net.minecraft.item.ItemStack;
+
+public interface INetworkEncodable {
+
+	/**
+	 * Used to get the current key from the item.
+	 * 
+	 * @param item item
+	 * @return string key of item
+	 */
+	String getEncryptionKey(ItemStack item);
+
+	/**
+	 * Encode the wireless frequency via the Controller.
+	 * 
+	 * @param item
+	 *            the wireless terminal.
+	 * @param encKey
+	 *            the wireless encryption key.
+	 * @param name
+	 *            null for now.
+	 */
+	void setEncryptionKey(ItemStack item, String encKey, String name);
+
+}

--- a/src/api/java/appeng/api/features/IP2PTunnelRegistry.java
+++ b/src/api/java/appeng/api/features/IP2PTunnelRegistry.java
@@ -1,0 +1,54 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.features;
+
+import net.minecraft.item.ItemStack;
+import appeng.api.config.TunnelType;
+
+/**
+ * A Registry for how p2p Tunnels are attuned
+ */
+public interface IP2PTunnelRegistry
+{
+
+	/**
+	 * Allows third parties to register items from their mod as potential
+	 * attunements for AE's P2P Tunnels
+	 * 
+	 * @param trigger
+	 *            - the item which triggers attunement
+	 * @param type
+	 *            - the type of tunnel
+	 */
+	public abstract void addNewAttunement(ItemStack trigger, TunnelType type);
+
+	/**
+	 * returns null if no attunement can be found.
+	 * 
+	 * @param trigger attunement trigger
+	 * @return null if no attunement can be found or attunement
+	 */
+	TunnelType getTunnelTypeByItem(ItemStack trigger);
+
+}

--- a/src/api/java/appeng/api/features/IPlayerRegistry.java
+++ b/src/api/java/appeng/api/features/IPlayerRegistry.java
@@ -1,0 +1,55 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.features;
+
+import net.minecraft.entity.player.EntityPlayer;
+
+import com.mojang.authlib.GameProfile;
+
+/**
+ * Maintains a save specific list of userids and username combinations this greatly simplifies storage internally and
+ * gives a common place to look up and get IDs for the security framework.
+ */
+public interface IPlayerRegistry
+{
+
+	/**
+	 * @param gameProfile user game profile
+	 * @return user id of a username.
+	 */
+	int getID(GameProfile gameProfile);
+
+	/**
+	 * @param player player
+	 * @return user id of a player entity.
+	 */
+	int getID(EntityPlayer player);
+
+	/**
+	 * @param playerID to be found player id
+	 * @return PlayerEntity, or null if the player could not be found.
+	 */
+	EntityPlayer findPlayer(int playerID);
+
+}

--- a/src/api/java/appeng/api/features/IRecipeHandlerRegistry.java
+++ b/src/api/java/appeng/api/features/IRecipeHandlerRegistry.java
@@ -1,0 +1,72 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.features;
+
+import appeng.api.recipes.ICraftHandler;
+import appeng.api.recipes.IRecipeHandler;
+import appeng.api.recipes.ISubItemResolver;
+
+public interface IRecipeHandlerRegistry
+{
+
+	/**
+	 * Add a new Recipe Handler to the parser.
+	 * 
+	 * MUST BE CALLED IN PRE-INIT
+	 * 
+	 * @param name name of crafthandler
+	 * @param handler class of crafthandler
+	 */
+	void addNewCraftHandler(String name, Class<? extends ICraftHandler> handler);
+
+	/**
+	 * Add a new resolver to the parser.
+	 * 
+	 * MUST BE CALLED IN PRE-INIT
+	 * 
+	 * @param sir sub item resolver
+	 */
+	void addNewSubItemResolver(ISubItemResolver sir);
+
+	/**
+	 * @param name name of crafting handler
+	 * @return A recipe handler by name, returns null on failure.
+	 */
+	ICraftHandler getCraftHandlerFor(String name);
+
+	/**
+	 * @return a new recipe handler, which can be used to parse, and read recipe files.
+	 */
+	public IRecipeHandler createNewRecipehandler();
+
+	/**
+	 * resolve sub items by name.
+	 * 
+	 * @param nameSpace namespace of item
+	 * @param itemName full name of item
+	 * @return ResolverResult or ResolverResultSet
+	 */
+	Object resolveItem(String nameSpace, String itemName);
+
+}

--- a/src/api/java/appeng/api/features/IRegistryContainer.java
+++ b/src/api/java/appeng/api/features/IRegistryContainer.java
@@ -1,0 +1,99 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.features;
+
+import appeng.api.movable.IMovableRegistry;
+import appeng.api.networking.IGridCacheRegistry;
+import appeng.api.storage.ICellRegistry;
+import appeng.api.storage.IExternalStorageRegistry;
+
+public interface IRegistryContainer
+{
+
+	/**
+	 * Use the movable registry to white list your tiles.
+	 */
+	IMovableRegistry movable();
+
+	/**
+	 * Add new Grid Caches for use during run time, only use during loading phase.
+	 */
+	IGridCacheRegistry gridCache();
+
+	/**
+	 * Add additional storage bus handlers to improve interplay with mod blocks that contains special inventories that
+	 * function unlike vanilla chests. AE uses this internally for barrels, DSU's, quantum chests, AE Networks and more.
+	 */
+	IExternalStorageRegistry externalStorage();
+
+	/**
+	 * Add additional special comparison functionality, AE Uses this internally for Bees.
+	 */
+	ISpecialComparisonRegistry specialComparison();
+
+	/**
+	 * Lets you register your items as wireless terminals
+	 */
+	IWirelessTermRegistry wireless();
+
+	/**
+	 * Allows you to register new cell types, these will function in drives
+	 */
+	ICellRegistry cell();
+
+	/**
+	 * Manage grinder recipes via API
+	 */
+	IGrinderRegistry grinder();
+
+	/**
+	 * get access to the locatable registry
+	 */
+	ILocatableRegistry locatable();
+
+	/**
+	 * get access to the p2p tunnel registry.
+	 */
+	IP2PTunnelRegistry p2pTunnel();
+
+	/**
+	 * get access to the ammo registry.
+	 */
+	IMatterCannonAmmoRegistry matterCannon();
+
+	/**
+	 * get access to the player registry
+	 */
+	IPlayerRegistry players();
+
+	/**
+	 * get access to the ae2 recipe api
+	 */
+	IRecipeHandlerRegistry recipes();
+
+	/**
+	 * get access to the world-gen api.
+	 */
+	IWorldGen worldgen();
+}

--- a/src/api/java/appeng/api/features/ISpecialComparisonRegistry.java
+++ b/src/api/java/appeng/api/features/ISpecialComparisonRegistry.java
@@ -1,0 +1,50 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.features;
+
+import net.minecraft.item.ItemStack;
+
+/**
+ * A Registry of any special comparison handlers for AE To use.
+ * 
+ */
+public interface ISpecialComparisonRegistry
+{
+
+	/**
+	 * return TheHandler or null.
+	 * 
+	 * @param stack item
+	 * @return a handler it found for a specific item
+	 */
+	IItemComparison getSpecialComparison(ItemStack stack);
+
+	/**
+	 * Register a new special comparison function with AE.
+	 * 
+	 * @param prov comparison provider
+	 */
+	public void addComparisonProvider(IItemComparisonProvider prov);
+
+}

--- a/src/api/java/appeng/api/features/IWirelessTermHandler.java
+++ b/src/api/java/appeng/api/features/IWirelessTermHandler.java
@@ -1,0 +1,69 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.features;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import appeng.api.util.IConfigManager;
+
+/**
+ * A handler for a wireless terminal.
+ */
+public interface IWirelessTermHandler extends INetworkEncodable
+{
+
+	/**
+	 * @param is wireless terminal
+	 * @return true, if usePower, hasPower, etc... can be called for the provided item
+	 */
+	boolean canHandle(ItemStack is);
+
+	/**
+	 * use an amount of power, in AE units
+	 * 
+	 * @param amount
+	 *            is in AE units ( 5 per MJ ), if you return false, the item should be dead and return false for
+	 *            hasPower
+	 * @param is wireless terminal
+	 * @return true if wireless terminal uses power
+	 */
+	boolean usePower(EntityPlayer player, double amount, ItemStack is);
+
+	/**
+	 * gets the power status of the item.
+	 * 
+	 * @param is wireless terminal
+	 * @return returns true if there is any power left.
+	 */
+	boolean hasPower(EntityPlayer player, double amount, ItemStack is);
+
+	/**
+	 * Return the config manager for the wireless terminal.
+	 * 
+	 * @param is wireless terminal
+	 * @return config manager of wireless terminal
+	 */
+	IConfigManager getConfigManager(ItemStack is);
+	
+}

--- a/src/api/java/appeng/api/features/IWirelessTermRegistry.java
+++ b/src/api/java/appeng/api/features/IWirelessTermRegistry.java
@@ -1,0 +1,62 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.features;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+
+/**
+ * Registration record for a Custom Cell handler.
+ */
+public interface IWirelessTermRegistry
+{
+
+	/**
+	 * add this handler to the list of other wireless handler.
+	 * 
+	 * @param handler wireless handler
+	 */
+	void registerWirelessHandler(IWirelessTermHandler handler);
+
+	/**
+	 * @param is item which might have a handler
+	 * @return true if there is a handler for this item
+	 */
+	boolean isWirelessTerminal(ItemStack is);
+
+	/**
+	 * @param is item with handler
+	 * @return a register handler for the item in question, or null if there
+	 *         isn't one
+	 */
+	IWirelessTermHandler getWirelessTerminalHandler(ItemStack is);
+
+	/**
+	 * opens the wireless terminal gui, the wireless terminal item, must be in
+	 * the active slot on the tool bar.
+	 */
+	void openWirelessTerminalGui(ItemStack item, World w, EntityPlayer player);
+
+}

--- a/src/api/java/appeng/api/features/IWorldGen.java
+++ b/src/api/java/appeng/api/features/IWorldGen.java
@@ -1,0 +1,45 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.features;
+
+import net.minecraft.world.World;
+import net.minecraft.world.WorldProvider;
+
+public interface IWorldGen
+{
+
+	public enum WorldGenType
+	{
+		CertusQuartz, ChargedCertusQuartz, Meteorites
+	}
+
+	public void disableWorldGenForProviderID(WorldGenType type, Class<? extends WorldProvider> provider);
+
+	public void enableWorldGenForDimension(WorldGenType type, int dimID);
+
+	public void disableWorldGenForDimension(WorldGenType type, int dimID);
+
+	boolean isWorldGenEnabled(WorldGenType type, World w);
+
+}

--- a/src/api/java/appeng/api/implementations/ICraftingPatternItem.java
+++ b/src/api/java/appeng/api/implementations/ICraftingPatternItem.java
@@ -1,0 +1,45 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.implementations;
+
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+import appeng.api.networking.crafting.ICraftingPatternDetails;
+
+/**
+ * Implemented on {@link Item}
+ */
+public interface ICraftingPatternItem
+{
+
+	/**
+	 * Access Details about a pattern
+	 * 
+	 * @param is pattern
+	 * @param w crafting world
+	 * @return details of pattern
+	 */
+	ICraftingPatternDetails getPatternForItem(ItemStack is, World w);
+}

--- a/src/api/java/appeng/api/implementations/tiles/IChestOrDrive.java
+++ b/src/api/java/appeng/api/implementations/tiles/IChestOrDrive.java
@@ -1,0 +1,63 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.implementations.tiles;
+
+import appeng.api.networking.IGridHost;
+import appeng.api.storage.ICellContainer;
+import appeng.api.util.IOrientable;
+
+public interface IChestOrDrive extends ICellContainer, IGridHost, IOrientable
+{
+
+	/**
+	 * @return how many slots are available. Chest has 1, Drive has 10.
+	 */
+	int getCellCount();
+
+	/**
+	 * 0 - cell is missing.
+	 * 
+	 * 1 - green,
+	 * 
+	 * 2 - orange,
+	 * 
+	 * 3 - red
+	 * 
+	 * @param slot slot index
+	 * @return status of the slot, one of the above indices.
+	 */
+	int getCellStatus(int slot);
+
+	/**
+	 * @return if the device is online you should check this before providing any other information.
+	 */
+	boolean isPowered();
+
+	/**
+	 * @param slot slot index
+	 * @return is the cell currently blinking to show activity.
+	 */
+	boolean isCellBlinking(int slot);
+
+}

--- a/src/api/java/appeng/api/implementations/tiles/ITileStorageMonitorable.java
+++ b/src/api/java/appeng/api/implementations/tiles/ITileStorageMonitorable.java
@@ -1,0 +1,38 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.implementations.tiles;
+
+import net.minecraftforge.common.util.ForgeDirection;
+import appeng.api.networking.security.BaseActionSource;
+import appeng.api.storage.IStorageMonitorable;
+
+/**
+ * Implemented on inventories that can share their inventories with other networks, best example, ME Interface.
+ */
+public interface ITileStorageMonitorable
+{
+
+	IStorageMonitorable getMonitorable(ForgeDirection side, BaseActionSource src);
+
+}

--- a/src/api/java/appeng/api/movable/IMovableHandler.java
+++ b/src/api/java/appeng/api/movable/IMovableHandler.java
@@ -1,0 +1,67 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.movable;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+
+public interface IMovableHandler
+{
+
+	/**
+	 * if you return true from this, your saying you can handle the class, not
+	 * that single entity, you cannot opt out of single entities.
+	 * 
+	 * @param myClass tile entity class
+	 * @param tile tile entity
+	 * @return true if it can handle moving
+	 */
+	boolean canHandle(Class<? extends TileEntity> myClass, TileEntity tile);
+
+	/**
+	 * request that the handler move the the tile from its current location to
+	 * the new one. the tile has already been invalidated, and the blocks have
+	 * already been fully moved.
+	 * 
+	 * Potential Example:
+	 *
+	 * <pre>
+	 * {@code
+	 * Chunk c = world.getChunkFromBlockCoords( x, z ); c.setChunkBlockTileEntity( x
+	 * & 0xF, y + y, z & 0xF, tile );
+	 * 
+	 * if ( c.isChunkLoaded ) { world.addTileEntity( tile ); world.markBlockForUpdate( x,
+	 * y, z ); }
+	 * }
+	 * </pre>
+	 * 
+	 * @param tile to be moved tile
+	 * @param world world of tile
+	 * @param x x coord of tile
+	 * @param y y coord of tile
+	 * @param z z coord of tile
+	 */
+	void moveTile(TileEntity tile, World world, int x, int y, int z);
+
+}

--- a/src/api/java/appeng/api/movable/IMovableRegistry.java
+++ b/src/api/java/appeng/api/movable/IMovableRegistry.java
@@ -1,0 +1,120 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.movable;
+
+import net.minecraft.block.Block;
+import net.minecraft.tileentity.TileEntity;
+
+/**
+ * Used to determine if a tile is marked as movable, a block will be considered movable, if...
+ * 
+ * 1. The Tile or its super classes have been white listed with whiteListTileEntity.
+ * 
+ * 2. The Tile has been register with the IMC ( which basically calls whiteListTileEntity. )
+ *
+ * 3. The Tile implements IMovableTile 4. A IMovableHandler is register that returns canHandle = true for the Tile
+ * Entity Class
+ * 
+ * IMC Example: FMLInterModComms.sendMessage( "appliedenergistics2", "movabletile", "appeng.common.AppEngTile" );
+ * 
+ * The movement process is as follows,
+ * 
+ * 1. IMovableTile.prepareToMove() or TileEntity.invalidate() depending on your opt-in method. 2. The tile will be
+ * removed from the world. 3. Its world, coordinates will be changed. *** this can be overridden with a IMovableHandler
+ * *** 4. It will then be re-added to the world, or a new world. 5. TileEntity.validate() 6. IMovableTile.doneMoving (
+ * if you implemented IMovableTile )
+ * 
+ * Please note, this is a 100% white list only feature, I will never opt in any non-vanilla, non-AE blocks. If you do
+ * not want to support your tiles being moved, you don't have to do anything.
+ * 
+ * I appreciate anyone that takes the effort to get their tiles to work with this system to create a better use
+ * experience.
+ * 
+ * If you need a build of deobf build of AE for testing, do not hesitate to ask.
+ */
+public interface IMovableRegistry
+{
+
+	/**
+	 * Black list a block from movement, please only use this to prevent exploits.
+	 * 
+	 * You can also use the IMC, FMLInterModComms.sendMessage( "appliedenergistics2", "whitelist-spatial",
+	 * "appeng.common.AppEngTile" );
+	 * 
+	 * @param blk block
+	 */
+	void blacklistBlock(Block blk);
+
+	/**
+	 * White list your tile entity with the registry.
+	 * 
+	 * You can also use the IMC, FMLInterModComms.sendMessage( "appliedenergistics2", "blacklist-block-spatial", new
+	 * ItemStack(...) );
+	 * 
+	 * If you tile is handled with IMovableHandler or IMovableTile you do not need to white list it.
+	 */
+	void whiteListTileEntity(Class<? extends TileEntity> c);
+
+	/**
+	 * @param te to be moved tile entity
+	 * @return true if the tile has accepted your request to move it
+	 */
+	boolean askToMove(TileEntity te);
+
+	/**
+	 * tells the tile you are done moving it.
+	 * 
+	 * @param te moved tile entity
+	 */
+	void doneMoving(TileEntity te);
+
+	/**
+	 * add a new handler movable handler.
+	 * 
+	 * @param handler moving handler
+	 */
+	void addHandler(IMovableHandler handler);
+
+	/**
+	 * handlers are used to perform movement, this allows you to override AE's internal version.
+	 * 
+	 * only valid after askToMove(...) = true
+	 * 
+	 * @param te tile entity
+	 * @return moving handler of tile entity
+	 */
+	IMovableHandler getHandler(TileEntity te);
+
+	/**
+	 * @return a copy of the default handler
+	 */
+	IMovableHandler getDefaultHandler();
+
+	/**
+	 * @param blk block
+	 * @return true if this block is blacklisted
+	 */
+	boolean isBlacklisted(Block blk);
+
+}

--- a/src/api/java/appeng/api/networking/GridFlags.java
+++ b/src/api/java/appeng/api/networking/GridFlags.java
@@ -1,0 +1,68 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.networking;
+
+/**
+ * Various flags to determine network node behavior.
+ */
+public enum GridFlags
+{
+	/**
+	 * import/export buses, terminals, and other devices that use network features, will use this setting.
+	 */
+	REQUIRE_CHANNEL,
+
+	/**
+	 * P2P ME tunnels use this setting.
+	 */
+	COMPRESSED_CHANNEL,
+
+	/**
+	 * cannot carry channels over this node.
+	 */
+	CANNOT_CARRY,
+
+	/**
+	 * Used by P2P Tunnels to prevent tunnels from tunneling recursively.
+	 */
+	CANNOT_CARRY_COMPRESSED,
+
+	/**
+	 * This node can transmit 32 signals, this should only apply to Tier2 Cable, P2P Tunnels, and Quantum Network
+	 * Bridges.
+	 */
+	DENSE_CAPACITY,
+
+	/**
+	 * This block is part of a multiblock, used in conjunction with REQUIRE_CHANNEL, and {@link IGridMultiblock} see this
+	 * interface for details.
+	 */
+	MULTIBLOCK,
+
+	/**
+	 * Indicates which path might be preferred, this only matters if two routes of equal length exist, ad only changes
+	 * the order they are processed in.
+	 */
+	PREFERRED
+}

--- a/src/api/java/appeng/api/networking/GridNotification.java
+++ b/src/api/java/appeng/api/networking/GridNotification.java
@@ -1,0 +1,32 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.networking;
+
+public enum GridNotification
+{
+	/**
+	 * the visible connections for this node have changed, useful for cable.
+	 */
+	ConnectionsChanged,
+}

--- a/src/api/java/appeng/api/networking/IGrid.java
+++ b/src/api/java/appeng/api/networking/IGrid.java
@@ -1,0 +1,94 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.networking;
+
+import appeng.api.networking.events.MENetworkEvent;
+import appeng.api.util.IReadOnlyCollection;
+
+/**
+ * Gives you access to Grid based information.
+ * 
+ * Don't Implement.
+ */
+public interface IGrid
+{
+
+	/**
+	 * Get Access to various grid modules
+	 * 
+	 * @param iface face
+	 * @return the IGridCache you requested.
+	 */
+	public <C extends IGridCache> C getCache(Class<? extends IGridCache> iface);
+
+	/**
+	 * Post an event into the network event bus.
+	 * 
+	 * @param ev
+	 *            - event to post
+	 * @return returns ev back to original poster
+	 */
+	public MENetworkEvent postEvent(MENetworkEvent ev);
+
+	/**
+	 * Post an event into the network event bus, but direct it at a single node.
+	 * 
+	 * @param ev
+	 *            event to post
+	 * @return returns ev back to original poster
+	 */
+	public MENetworkEvent postEventTo(IGridNode node, MENetworkEvent ev);
+
+	/**
+	 * get a list of the diversity of classes, you can use this to better detect which machines your interested in,
+	 * rather then iterating the entire grid to test them.
+	 * 
+	 * @return IReadOnlyCollection of all available host types (Of Type IGridHost).
+	 */
+	public IReadOnlyCollection<Class<? extends IGridHost>> getMachinesClasses();
+
+	/**
+	 * Get machines on the network.
+	 * 
+	 * @param gridHostClass class of the grid host
+	 * @return IMachineSet of all nodes belonging to hosts of specified class.
+	 */
+	public IMachineSet getMachines(Class<? extends IGridHost> gridHostClass);
+
+	/**
+	 * @return IReadOnlyCollection for all nodes on the network, node visitors are preferred.
+	 */
+	IReadOnlyCollection<IGridNode> getNodes();
+
+	/**
+	 * @return true if the last node has been removed from the grid.
+	 */
+	public boolean isEmpty();
+
+	/**
+	 * @return the node considered the pivot point of the grid.
+	 */
+	public IGridNode getPivot();
+
+}

--- a/src/api/java/appeng/api/networking/IGridBlock.java
+++ b/src/api/java/appeng/api/networking/IGridBlock.java
@@ -1,0 +1,112 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.networking;
+
+import appeng.api.parts.IPart;
+import appeng.api.util.AEColor;
+import appeng.api.util.DimensionalCoord;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.common.util.ForgeDirection;
+
+import java.util.EnumSet;
+
+/**
+ * An Implementation is required to create your node for IGridHost
+ * 
+ * Implement for use with IGridHost
+ */
+public interface IGridBlock
+{
+
+	/**
+	 * how much power to drain per tick as part of idle network usage.
+	 * 
+	 * if the value of this changes, you must post a MENetworkPowerIdleChange
+	 * 
+	 * @return ae/t to use.
+	 */
+	double getIdlePowerUsage();
+
+	/**
+	 * Various flags that AE uses to modify basic behavior for various parts of the network.
+	 * 
+	 * @return Set of flags for this IGridBlock
+	 */
+	EnumSet<GridFlags> getFlags();
+
+	/**
+	 * generally speaking you will return true for this, the one exception is buses, or worm holes where the node
+	 * represents something that isn't a real connection in the world, but rather one represented internally to the
+	 * block.
+	 * 
+	 * @return if the world can connect to this node, and the node can connect to the world.
+	 */
+	boolean isWorldAccessible();
+
+	/**
+	 * @return current location of this node
+	 */
+	DimensionalCoord getLocation();
+
+	/**
+	 * @return Transparent, or a valid color, NULL IS NOT A VALID RETURN
+	 */
+	AEColor getGridColor();
+
+	/**
+	 * Notifies your IGridBlock that changes were made to your connections
+	 */
+	void onGridNotification(GridNotification notification);
+
+	/**
+	 * Update Blocks network/connection/booting status. grid,
+	 *
+	 * @param grid grid
+	 * @param channelsInUse used channels
+	 */
+	public void setNetworkStatus(IGrid grid, int channelsInUse);
+
+	/**
+	 * Determine which sides of the block can be connected too, only used when isWorldAccessible returns true, not used
+	 * for {@link IPart} implementations.
+	 */
+	EnumSet<ForgeDirection> getConnectableSides();
+
+	/**
+	 * @return the IGridHost for the node, this will be an IGridPart or a TileEntity generally speaking.
+	 */
+	IGridHost getMachine();
+
+	/**
+	 * called when the grid for the node has changed, the general grid state should not be trusted at this point.
+	 */
+	void gridChanged();
+
+	/**
+	 * Determines what item stack is used to render this node in the GUI.
+	 * 
+	 * @return the render item stack to use to render this node, null is valid, and will not show this node.
+	 */
+	public ItemStack getMachineRepresentation();
+}

--- a/src/api/java/appeng/api/networking/IGridCache.java
+++ b/src/api/java/appeng/api/networking/IGridCache.java
@@ -1,0 +1,94 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.networking;
+
+/**
+ * 
+ * Allows you to create a network wise service, AE2 uses these for providing
+ * item, spatial, and tunnel services.
+ * 
+ * Any Class that implements this, should have a public default constructor that
+ * takes a single argument of type IGrid.
+ * 
+ */
+public interface IGridCache
+{
+
+	/**
+	 * Called each tick for the network, allows you to have active network wide
+	 * behaviors.
+	 * 
+	 */
+	void onUpdateTick();
+
+	/**
+	 * inform your cache, that a machine was removed from the grid.
+	 * 
+	 * Important: Do not trust the grids state in this method, interact only
+	 * with the node you are passed, if you need to manage other grid
+	 * information, do it on the next updateTick.
+	 * 
+	 * @param gridNode removed from that grid
+	 * @param machine to be removed machine
+	 */
+	void removeNode(IGridNode gridNode, IGridHost machine);
+
+	/**
+	 * informs you cache that a machine was added to the grid.
+	 * 
+	 * Important: Do not trust the grids state in this method, interact only
+	 * with the node you are passed, if you need to manage other grid
+	 * information, do it on the next updateTick.
+	 * 
+	 * @param gridNode added to grid node
+	 * @param machine to be added machine
+	 */
+	void addNode(IGridNode gridNode, IGridHost machine);
+
+	/**
+	 * Called when a grid splits into two grids, AE will call a split as it
+	 * Iteratively processes changes. The destination should receive half, and
+	 * the current cache should receive half.
+	 * 
+	 * @param destinationStorage storage which receives half of old grid
+	 */
+	void onSplit(IGridStorage destinationStorage);
+
+	/**
+	 * Called when two grids merge into one, AE will call a join as it
+	 * Iteratively processes changes. Use this method to incorporate all the
+	 * data from the source into your cache.
+	 * 
+	 * @param sourceStorage old storage
+	 */
+	void onJoin(IGridStorage sourceStorage);
+
+	/**
+	 * Called when saving changes,
+	 * 
+	 * @param destinationStorage storage
+	 */
+	void populateGridStorage(IGridStorage destinationStorage);
+
+}

--- a/src/api/java/appeng/api/networking/IGridCacheRegistry.java
+++ b/src/api/java/appeng/api/networking/IGridCacheRegistry.java
@@ -1,0 +1,50 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.networking;
+
+import java.util.HashMap;
+
+/**
+ * A registry of grid caches to extend grid functionality.
+ */
+public interface IGridCacheRegistry
+{
+
+	/**
+	 * Register a new grid cache for use during operation, must be called during the loading phase.
+	 * 
+	 * @param iface grid cache class
+	 */
+	void registerGridCache(Class<? extends IGridCache> iface, Class<? extends IGridCache> implementation);
+
+	/**
+	 * requests a new instance of a grid cache for use, used internally
+	 * 
+	 * @param grid grid
+	 * 
+	 * @return a new HashMap of IGridCaches from the registry, called from IGrid when constructing a new grid.
+	 */
+	HashMap<Class<? extends IGridCache>, IGridCache> createCacheInstance(IGrid grid);
+
+}

--- a/src/api/java/appeng/api/networking/IGridConnection.java
+++ b/src/api/java/appeng/api/networking/IGridConnection.java
@@ -1,0 +1,81 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.networking;
+
+import net.minecraftforge.common.util.ForgeDirection;
+
+/**
+ * Access to AE's internal grid connections.
+ * 
+ * Messing with connection is generally completely unnecessary, you should be able to just use IGridNode.updateState()
+ * to have AE manage them for you.
+ * 
+ * Don't Implement.
+ */
+public interface IGridConnection
+{
+
+	/**
+	 * lets you get the opposing node of the connection by passing your own node.
+	 * 
+	 * @param gridNode current grid node
+	 * @return the IGridNode which represents the opposite side of the connection.
+	 */
+	IGridNode getOtherSide(IGridNode gridNode);
+
+	/**
+	 * determine the direction of the connection based on your node.
+	 * 
+	 * @param gridNode current grid node
+	 * @return the direction of the connection, only valid for in world connections.
+	 */
+	ForgeDirection getDirection(IGridNode gridNode);
+
+	/**
+	 * by destroying a connection you may create new grids, and trigger un-expected behavior, you should only destroy
+	 * connections if you created them.
+	 */
+	void destroy();
+
+	/**
+	 * @return node A
+	 */
+	IGridNode a();
+
+	/**
+	 * @return node B
+	 */
+	IGridNode b();
+
+	/**
+	 * @return if the connection is invisible this returns false
+	 */
+	boolean hasDirection();
+
+	/**
+	 * @return how many channels pass over this connections.
+	 */
+	int getUsedChannels();
+
+}

--- a/src/api/java/appeng/api/networking/IGridHost.java
+++ b/src/api/java/appeng/api/networking/IGridHost.java
@@ -1,0 +1,66 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.networking;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.ForgeDirection;
+import appeng.api.parts.IPart;
+import appeng.api.util.AECableType;
+
+/**
+ * 
+ * Implement to create a networked {@link TileEntity} or {@link IPart} must
+ * be implemented for a part, or tile entity to become part of a grid.
+ * 
+ */
+public interface IGridHost
+{
+
+	/**
+	 * get the grid node for a particular side of a block, you can return null,
+	 * by returning a valid node later and calling updateState, you can join the
+	 * Grid when your block is ready.
+	 * 
+	 * @param dir
+	 *            feel free to ignore this, most blocks will use the same node
+	 *            for every side.
+	 * @return a new IGridNode, create these with
+	 *         AEApi.instance().createGridNode( MyIGridBlock )
+	 */
+	public IGridNode getGridNode(ForgeDirection dir);
+
+	/**
+	 * Determines how cables render when they connect to this block. Priority is
+	 * Smart &gt; Covered &gt; Glass
+	 * 
+	 * @param dir direction
+	 */
+	public AECableType getCableConnectionType(ForgeDirection dir);
+
+	/**
+	 * break this host, its violating security rules, just break your block, or part.
+	 */
+	public void securityBreak();
+
+}

--- a/src/api/java/appeng/api/networking/IGridNode.java
+++ b/src/api/java/appeng/api/networking/IGridNode.java
@@ -1,0 +1,164 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.networking;
+
+import appeng.api.IAppEngApi;
+import appeng.api.util.IReadOnlyCollection;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
+
+import java.util.EnumSet;
+
+/**
+ * 
+ * Gives you a view into your Nodes connections and information.
+ * 
+ * updateState, getGrid, destroy are required to implement a proper IGridHost.
+ * 
+ * Don't Implement; Acquire from {@link IAppEngApi}.createGridNode
+ * 
+ */
+public interface IGridNode
+{
+
+	/**
+	 * lets you walk the grid stating at the current node using a IGridVisitor, generally not needed, please use only if
+	 * required.
+	 * 
+	 * @param visitor visitor
+	 */
+	void beginVisit(IGridVisitor visitor);
+
+	/**
+	 * inform the node that your IGridBlock has changed its internal state, and force the node to update.
+	 * 
+	 * ALWAYS make sure that your tile entity is in the world, and has its node properly saved to be returned from the
+	 * host before updating state,
+	 * 
+	 * If your entity is not in the world, or if you IGridHost returns a different node for the same side you will
+	 * likely crash the game.
+	 * 
+	 */
+	void updateState();
+
+	/**
+	 * get the machine represented by the node.
+	 * 
+	 * @return grid host
+	 */
+	IGridHost getMachine();
+
+	/**
+	 * get the grid for the node, this can change at a moments notice.
+	 * 
+	 * @return grid
+	 */
+	IGrid getGrid();
+
+	/**
+	 * By destroying your node, you destroy any connections, and its existence in the grid, use in invalidate, or
+	 * onChunkUnload
+	 */
+	void destroy();
+
+	/**
+	 * @return the world the node is located in
+	 */
+	World getWorld();
+
+	/**
+	 * 
+	 * @return a set of the connected sides, UNKNOWN represents an invisible connection
+	 */
+	EnumSet<ForgeDirection> getConnectedSides();
+
+	/**
+	 * lets you iterate a nodes connections
+	 * 
+	 * @return grid connections
+	 */
+	IReadOnlyCollection<IGridConnection> getConnections();
+
+	/**
+	 * @return the IGridBlock for this node
+	 */
+	IGridBlock getGridBlock();
+
+	/**
+	 * Reflects the networks status, returns true only if the network is powered, and the network is not booting, this
+	 * also takes into account channels.
+	 * 
+	 * @return true if is Network node active, and participating.
+	 */
+	boolean isActive();
+
+	/**
+	 * this should be called for each node you create, if you have a nodeData compound to load from, you can store all
+	 * your nods on a single compound using name.
+	 * 
+	 * Important: You must call this before updateState.
+	 * 
+	 * @param name nbt name
+	 * @param nodeData to be loaded data
+	 */
+	void loadFromNBT(String name, NBTTagCompound nodeData);
+
+	/**
+	 * this should be called for each node you maintain, you can save all your nodes to the same tag with different
+	 * names, if you fail to complete the load / save procedure, network state may be lost between game load/saves.
+	 * 
+	 * @param name nbt name
+	 * @param nodeData to be saved data
+	 */
+	void saveToNBT(String name, NBTTagCompound nodeData);
+
+	/**
+	 * @return if the node's channel requirements are currently met, use this for display purposes, use isActive for
+	 *         status.
+	 */
+	boolean meetsChannelRequirements();
+
+	/**
+	 * see if this node has a certain flag
+	 * 
+	 * @param flag flags
+	 * @return true if has flag
+	 */
+	boolean hasFlag(GridFlags flag);
+
+	/**
+	 * tell the node who was responsible for placing it, failure to do this may result in in-compatibility with the
+	 * security system. Called instead of loadFromNBT when initially placed, once set never required again, the value is saved with the Node NBT.
+	 * 
+	 * @param playerID new player id
+	 */
+	void setPlayerID(int playerID);
+
+	/**
+	 * @return the ownerID this represents the person who placed the node.
+	 */
+	int getPlayerID();
+
+}

--- a/src/api/java/appeng/api/networking/IGridStorage.java
+++ b/src/api/java/appeng/api/networking/IGridStorage.java
@@ -1,0 +1,41 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.networking;
+
+import net.minecraft.nbt.NBTTagCompound;
+
+public interface IGridStorage
+{
+
+	/**
+	 * @return an NBTTagCompound that can be read, and written too.
+	 */
+	NBTTagCompound dataObject();
+
+	/**
+	 * @return the id for this grid storage object, used internally
+	 */
+	long getID();
+
+}

--- a/src/api/java/appeng/api/networking/IGridVisitor.java
+++ b/src/api/java/appeng/api/networking/IGridVisitor.java
@@ -1,0 +1,44 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.networking;
+
+/**
+ * Simple Visitor pattern access to network nodes.
+ */
+public interface IGridVisitor
+{
+
+	/**
+	 * Called for each node on the network.
+	 * 
+	 * By returning false your informing the host to stop visiting nodes beyond the current node.
+	 * 
+	 * @param n
+	 *            the current node.
+	 * 
+	 * @return true to continue visiting nodes beyond this node.
+	 */
+	public boolean visitNode(IGridNode n);
+
+}

--- a/src/api/java/appeng/api/networking/IMachineSet.java
+++ b/src/api/java/appeng/api/networking/IMachineSet.java
@@ -1,0 +1,36 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.networking;
+
+import appeng.api.util.IReadOnlyCollection;
+
+public interface IMachineSet extends IReadOnlyCollection<IGridNode>
+{
+
+	/**
+	 * @return the machine class for this set.
+	 */
+	Class<? extends IGridHost> getMachineClass();
+
+}

--- a/src/api/java/appeng/api/networking/crafting/ICraftingCPU.java
+++ b/src/api/java/appeng/api/networking/crafting/ICraftingCPU.java
@@ -1,0 +1,58 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.networking.crafting;
+
+import appeng.api.networking.security.BaseActionSource;
+import appeng.api.networking.storage.IBaseMonitor;
+import appeng.api.storage.data.IAEItemStack;
+
+public interface ICraftingCPU extends IBaseMonitor<IAEItemStack>
+{
+
+	/**
+	 * @return true if the CPU currently has a job.
+	 */
+	boolean isBusy();
+
+	/**
+	 * @return the action source for the CPU.
+	 */
+	BaseActionSource getActionSource();
+
+	/**
+	 * @return the available storage in bytes
+	 */
+	long getAvailableStorage();
+
+	/**
+	 * @return the number of co-processors in the CPU.
+	 */
+	int getCoProcessors();
+
+	/**
+	 * @return an empty string or the name of the cpu.
+	 */
+	String getName();
+
+}

--- a/src/api/java/appeng/api/networking/crafting/ICraftingCallback.java
+++ b/src/api/java/appeng/api/networking/crafting/ICraftingCallback.java
@@ -1,0 +1,37 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.networking.crafting;
+
+public interface ICraftingCallback
+{
+
+	/**
+	 * this call back is synchronized with the world you passed.
+	 * 
+	 * @param job
+	 *            - final job
+	 */
+	public void calculationComplete(ICraftingJob job);
+
+}

--- a/src/api/java/appeng/api/networking/crafting/ICraftingGrid.java
+++ b/src/api/java/appeng/api/networking/crafting/ICraftingGrid.java
@@ -1,0 +1,107 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.networking.crafting;
+
+import appeng.api.networking.IGrid;
+import appeng.api.networking.IGridCache;
+import appeng.api.networking.security.BaseActionSource;
+import appeng.api.storage.data.IAEItemStack;
+import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableSet;
+import net.minecraft.world.World;
+
+import java.util.concurrent.Future;
+
+public interface ICraftingGrid extends IGridCache
+{
+
+	/**
+	 * @param whatToCraft requested craft
+	 * @param world crafting world
+	 * @param slot slot index
+	 * @param details pattern details
+	 * @return a collection of crafting patterns for the item in question.
+	 */
+	ImmutableCollection<ICraftingPatternDetails> getCraftingFor(IAEItemStack whatToCraft, ICraftingPatternDetails details, int slot, World world);
+
+	/**
+	 * Begin calculating a crafting job.
+	 * 
+	 * @param world crafting world
+	 * @param grid network
+	 * @param actionSrc source
+	 * @param craftWhat result
+	 * @param callback callback
+	 *            -- optional
+	 * 
+	 * @return a future which will at an undetermined point in the future get you the {@link ICraftingJob} do not wait
+	 *         on this, your be waiting forever.
+	 */
+	Future<ICraftingJob> beginCraftingJob(World world, IGrid grid, BaseActionSource actionSrc, IAEItemStack craftWhat, ICraftingCallback callback);
+
+	/**
+	 * Submit the job to the Crafting system for processing.
+	 * 
+	 * @param job
+	 *            - the crafting job from beginCraftingJob
+	 * @param requestingMachine
+	 *            - a machine if its being requested via automation, may be null.
+	 * @param target
+	 *            - can be null
+	 * 
+	 * @param prioritizePower
+	 *            - if cpu is null, this determine if the system should prioritize power, or if it should find the lower
+	 *            end cpus, automatic processes generally should pick lower end cpus.
+	 * 
+	 * @param src
+	 *            - the action source to use when starting the job, this will be used for extracting items, should
+	 *            usually be the same as the one provided to beginCraftingJob.
+	 * 
+	 * @return null ( if failed ) or an {@link ICraftingLink} other wise, if you send requestingMachine you need to
+	 *         properly keep track of this and handle the nbt saving and loading of the object as well as the
+	 *         {@link ICraftingRequester} methods. if you send null, this object should be discarded after verifying the
+	 *         return state.
+	 */
+	ICraftingLink submitJob(ICraftingJob job, ICraftingRequester requestingMachine, ICraftingCPU target, boolean prioritizePower, BaseActionSource src);
+
+	/**
+	 * @return list of all the crafting cpus on the grid
+	 */
+	ImmutableSet<ICraftingCPU> getCpus();
+
+	/**
+	 * @param what to be requested item
+	 * @return true if the item can be requested via a crafting emitter.
+	 */
+	boolean canEmitFor(IAEItemStack what);
+
+	/**
+	 * is this item being crafted?
+	 * 
+	 * @param aeStackInSlot item being crafted
+	 * @return true if it is being crafting
+	 */
+	boolean isRequesting(IAEItemStack aeStackInSlot);
+
+}

--- a/src/api/java/appeng/api/networking/crafting/ICraftingJob.java
+++ b/src/api/java/appeng/api/networking/crafting/ICraftingJob.java
@@ -1,0 +1,56 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.networking.crafting;
+
+import appeng.api.storage.data.IAEItemStack;
+import appeng.api.storage.data.IItemList;
+
+public interface ICraftingJob
+{
+
+	/**
+	 * @return if this job is a simulation, simulations cannot be submitted and only represent 1 possible future
+	 *         crafting job with fake items.
+	 */
+	boolean isSimulation();
+
+	/**
+	 * @return total number of bytes to process this job.
+	 */
+	long getByteTotal();
+
+	/**
+	 * Populates the plan list with stack size, and requestable values that represent the stored, and crafting job
+	 * contents respectively.
+	 * 
+	 * @param plan plan
+	 */
+	void populatePlan(IItemList<IAEItemStack> plan);
+
+	/**
+	 * @return the final output of the job.
+	 */
+	IAEItemStack getOutput();
+
+}

--- a/src/api/java/appeng/api/networking/crafting/ICraftingLink.java
+++ b/src/api/java/appeng/api/networking/crafting/ICraftingLink.java
@@ -1,0 +1,63 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.networking.crafting;
+
+import net.minecraft.nbt.NBTTagCompound;
+
+public interface ICraftingLink
+{
+
+	/**
+	 * @return true if the job was canceled.
+	 */
+	boolean isCanceled();
+
+	/**
+	 * @return true if the job was completed.
+	 */
+	boolean isDone();
+
+	/**
+	 * cancels the job.
+	 */
+	void cancel();
+
+	/**
+	 * @return true if this link was generated without a requesting machine, such as a player generated request.
+	 */
+	boolean isStandalone();
+
+	/**
+	 * write the link to an NBT Tag
+	 * 
+	 * @param tag to be written data
+	 */
+	void writeToNBT(NBTTagCompound tag);
+
+	/**
+	 * @return the crafting ID for this link.
+	 */
+	String getCraftingID();
+
+}

--- a/src/api/java/appeng/api/networking/crafting/ICraftingPatternDetails.java
+++ b/src/api/java/appeng/api/networking/crafting/ICraftingPatternDetails.java
@@ -1,0 +1,106 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.networking.crafting;
+
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+import appeng.api.implementations.ICraftingPatternItem;
+import appeng.api.storage.data.IAEItemStack;
+
+/**
+ * do not implement provided by {@link ICraftingPatternItem}
+ * 
+ * caching this instance will increase performance of validation and checks.
+ */
+public interface ICraftingPatternDetails
+{
+
+	/**
+	 * @return source item.
+	 */
+	ItemStack getPattern();
+
+	/**
+	 * @param slotIndex specific slot index
+	 * @param itemStack item in slot
+	 * @param world crafting world
+	 * 
+	 * @return if an item can be used in the specific slot for this pattern.
+	 */
+	boolean isValidItemForSlot(int slotIndex, ItemStack itemStack, World world);
+
+	/**
+	 * @return if this pattern is a crafting pattern ( work bench )
+	 */
+	boolean isCraftable();
+
+	/**
+	 * @return a list of the inputs, will include nulls.
+	 */
+	IAEItemStack[] getInputs();
+
+	/**
+	 * @return a list of the inputs, will be clean
+	 */
+	IAEItemStack[] getCondensedInputs();
+
+	/**
+	 * @return a list of the outputs, will be clean
+	 */
+	IAEItemStack[] getCondensedOutputs();
+
+	/**
+	 * @return a list of the outputs, will include nulls.
+	 */
+	IAEItemStack[] getOutputs();
+
+	/**
+	 * @return if this pattern is enabled to support substitutions.
+	 */
+	boolean canSubstitute();
+
+	/**
+	 * Allow using this instance of the pattern details to preform the crafting action with performance enhancements.
+	 * 
+	 * @param craftingInv inventory
+	 * @param world crafting world
+	 * @return the crafted ( work bench ) item.
+	 */
+	ItemStack getOutput(InventoryCrafting craftingInv, World world);
+
+	/**
+	 * Set the priority the of this pattern.
+	 * 
+	 * @param priority priority of pattern
+	 */
+	void setPriority(int priority);
+
+	/**
+	 * Get the priority of this pattern
+	 *
+	 * @return the priority of this pattern
+	 */
+	int getPriority();
+}

--- a/src/api/java/appeng/api/networking/crafting/ICraftingRequester.java
+++ b/src/api/java/appeng/api/networking/crafting/ICraftingRequester.java
@@ -1,0 +1,60 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.networking.crafting;
+
+import appeng.api.config.Actionable;
+import appeng.api.networking.security.IActionHost;
+import appeng.api.storage.data.IAEItemStack;
+
+import com.google.common.collect.ImmutableSet;
+
+public interface ICraftingRequester extends IActionHost
+{
+
+	/**
+	 * called when the host is added to the grid, and should return all crafting links it poses so they can be connected
+	 * with the cpu that hosts the job.
+	 * 
+	 * @return set of jobs, or an empty list.
+	 */
+	ImmutableSet<ICraftingLink> getRequestedJobs();
+
+	/**
+	 * items are injected into the requester as they are completed, any items that cannot be taken, or are unwanted can
+	 * be returned.
+	 * 
+	 * @param items item
+	 * @param mode action mode
+	 * @return unwanted item
+	 */
+	IAEItemStack injectCraftedItems(ICraftingLink link, IAEItemStack items, Actionable mode);
+
+	/**
+	 * called when the job changes from in progress, to either complete, or canceled.
+	 * 
+	 * after this call the crafting link is "dead" and should be discarded.
+	 */
+	void jobStateChange(ICraftingLink link);
+
+}

--- a/src/api/java/appeng/api/networking/energy/IEnergyGrid.java
+++ b/src/api/java/appeng/api/networking/energy/IEnergyGrid.java
@@ -1,0 +1,105 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.networking.energy;
+
+import appeng.api.config.Actionable;
+import appeng.api.networking.IGridCache;
+import appeng.api.networking.events.MENetworkPowerStatusChange;
+
+/**
+ * AE's Power system.
+ */
+public interface IEnergyGrid extends IGridCache, IEnergySource, IEnergyGridProvider
+{
+
+	/**
+	 * @return the current calculated idle energy drain each tick, is used internally to drain power for each tick.
+	 */
+	public double getIdlePowerUsage();
+
+	/**
+	 * @return the average power drain over the past 10 ticks, includes idle usage during this time, and all use of
+	 *         extractPower.
+	 */
+	public double getAvgPowerUsage();
+
+	/**
+	 * @return the average energy injected into the system per tick, for the last 10 ticks.
+	 */
+	public double getAvgPowerInjection();
+
+	/**
+	 * AE maintains an idle draw of power separate from active power draw, it condenses this into a single operation
+	 * that determines the networks "powered state" if the network is considered off-line, your machines should not
+	 * function.
+	 * 
+	 * {@link MENetworkPowerStatusChange} events are posted when this value changes if you need to be notified of the
+	 * change, most machines can simply test the value when they operate.
+	 * 
+	 * @return if the network is powered or not.
+	 */
+	public boolean isNetworkPowered();
+
+	/**
+	 * AE will accept any power, and store it, to maintain sanity please don't send more then 10,000 at a time.
+	 * 
+	 * IMPORTANT: Network power knows no bounds, for less spamy power flow, networks can store more then their allotted
+	 * storage, however, it should be kept to a minimum, to help with this, this method returns the networks current
+	 * OVERFLOW, this is not energy you can store some where else, its already stored in the network, you can extract it
+	 * if you want, however it it owned by the network, this is different then IAEEnergyStore
+	 * 
+	 * Another important note, is that if a network that had overflow is deleted, its power is gone, this is one of the
+	 * reasons why keeping overflow to a minimum is important.
+	 * 
+	 * @param amt
+	 *            power to inject into the network
+	 * @param mode
+	 *            should the action be simulated or performed?
+	 * @return the amount of power that the network has OVER the limit.
+	 */
+	public double injectPower(double amt, Actionable mode);
+
+	/**
+	 * this is should be considered an estimate, and not relied upon for real calculations.
+	 * 
+	 * @return estimated available power.
+	 */
+	public double getStoredPower();
+
+	/**
+	 * this is should be considered an estimate, and not relied upon for real calculations.
+	 * 
+	 * @return estimated available power.
+	 */
+	double getMaxStoredPower();
+
+	/**
+	 * Calculation will be capped at maxRequired, this improves performance by limiting the number of nodes needed to
+	 * calculate the demand.
+	 * 
+	 * @return Amount of power required to charge the grid, in AE.
+	 */
+	public double getEnergyDemand(double maxRequired);
+
+}

--- a/src/api/java/appeng/api/networking/energy/IEnergyGridProvider.java
+++ b/src/api/java/appeng/api/networking/energy/IEnergyGridProvider.java
@@ -1,0 +1,51 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.networking.energy;
+
+import java.util.Set;
+
+import appeng.api.config.Actionable;
+
+/**
+ * internal use only.
+ */
+public interface IEnergyGridProvider
+{
+
+	/**
+	 * internal use only
+	 */
+	public double extractAEPower(double amt, Actionable mode, Set<IEnergyGrid> seen);
+
+	/**
+	 * internal use only
+	 */
+	public double injectAEPower(double amt, Actionable mode, Set<IEnergyGrid> seen);
+
+	/**
+	 * internal use only
+	 */
+	public double getEnergyDemand(double d, Set<IEnergyGrid> seen);
+
+}

--- a/src/api/java/appeng/api/networking/energy/IEnergySource.java
+++ b/src/api/java/appeng/api/networking/energy/IEnergySource.java
@@ -1,0 +1,41 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.networking.energy;
+
+import appeng.api.config.Actionable;
+import appeng.api.config.PowerMultiplier;
+
+public interface IEnergySource
+{
+
+	/**
+	 * Extract power from the network.
+	 * 
+	 * @param amt extracted power
+	 * @param mode should the action be simulated or performed?
+	 * @return returns extracted power.
+	 */
+	public double extractAEPower(double amt, Actionable mode, PowerMultiplier usePowerMultiplier);
+
+}

--- a/src/api/java/appeng/api/networking/events/MENetworkEvent.java
+++ b/src/api/java/appeng/api/networking/events/MENetworkEvent.java
@@ -1,0 +1,76 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.networking.events;
+
+import appeng.api.networking.IGrid;
+
+/**
+ * Part of AE's Event Bus.
+ * 
+ * Posted via {@link IGrid}.postEvent or {@link IGrid}.postEventTo
+ */
+public class MENetworkEvent
+{
+
+	private int visited = 0;
+	private boolean canceled = false;
+
+	/**
+	 * Call to prevent AE from posting the event to any further objects.
+	 */
+	public void cancel()
+	{
+		canceled = true;
+	}
+
+	/**
+	 * called by AE after each object is called to cancel any future calls.
+	 * 
+	 * @return true to cancel future calls
+	 */
+	public boolean isCanceled()
+	{
+		return canceled;
+	}
+
+	/**
+	 * the number of objects that were visited by the event.
+	 * 
+	 * @return number of visitors
+	 */
+	public int getVisitedObjects()
+	{
+		return visited;
+	}
+
+	/**
+	 * Called by AE after iterating the event subscribers.
+	 * 
+	 * @param v current number of visitors
+	 */
+	public void setVisitedObjects(int v)
+	{
+		visited = v;
+	}
+}

--- a/src/api/java/appeng/api/networking/events/MENetworkPowerStatusChange.java
+++ b/src/api/java/appeng/api/networking/events/MENetworkPowerStatusChange.java
@@ -1,0 +1,39 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.networking.events;
+
+import appeng.api.networking.IGridNode;
+import appeng.api.networking.energy.IEnergyGrid;
+
+/**
+ * Posted by the network when the power status of the network goes up or down,
+ * the change is reflected via the {@link IEnergyGrid}.isNetworkPowered() or via
+ * {@link IGridNode}.isActive()
+ * 
+ * Note: Most machines just need to check {@link IGridNode}.isActive()
+ */
+public class MENetworkPowerStatusChange extends MENetworkEvent
+{
+
+}

--- a/src/api/java/appeng/api/networking/security/BaseActionSource.java
+++ b/src/api/java/appeng/api/networking/security/BaseActionSource.java
@@ -1,0 +1,39 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.networking.security;
+
+public class BaseActionSource
+{
+
+	public boolean isPlayer()
+	{
+		return false;
+	}
+
+	public boolean isMachine()
+	{
+		return false;
+	}
+
+}

--- a/src/api/java/appeng/api/networking/security/IActionHost.java
+++ b/src/api/java/appeng/api/networking/security/IActionHost.java
@@ -1,0 +1,42 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.networking.security;
+
+import appeng.api.networking.IGridHost;
+import appeng.api.networking.IGridNode;
+
+public interface IActionHost extends IGridHost
+{
+
+	/**
+	 * Used to for calculating security rules, you must supply a node from your
+	 * IGridHost for the security test, this should be the primary node for the
+	 * machine, unless the action is preformed by a non primary node.
+	 * 
+	 * @return the the gridnode that actions from this IGridHost are preformed
+	 *         by.
+	 */
+	IGridNode getActionableNode();
+
+}

--- a/src/api/java/appeng/api/networking/security/MachineSource.java
+++ b/src/api/java/appeng/api/networking/security/MachineSource.java
@@ -1,0 +1,41 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.networking.security;
+
+public class MachineSource extends BaseActionSource
+{
+
+	public final IActionHost via;
+
+	@Override
+	public boolean isMachine()
+	{
+		return true;
+	}
+
+	public MachineSource(IActionHost v) {
+		via = v;
+	}
+
+}

--- a/src/api/java/appeng/api/networking/storage/IBaseMonitor.java
+++ b/src/api/java/appeng/api/networking/storage/IBaseMonitor.java
@@ -1,0 +1,42 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.networking.storage;
+
+import appeng.api.storage.IMEMonitorHandlerReceiver;
+import appeng.api.storage.data.IAEStack;
+
+public interface IBaseMonitor<T extends IAEStack>
+{
+
+	/**
+	 * add a new Listener to the monitor, be sure to properly remove yourself when your done.
+	 */
+	void addListener(IMEMonitorHandlerReceiver<T> l, Object verificationToken);
+
+	/**
+	 * remove a Listener to the monitor.
+	 */
+	void removeListener(IMEMonitorHandlerReceiver<T> l);
+
+}

--- a/src/api/java/appeng/api/networking/storage/IStorageGrid.java
+++ b/src/api/java/appeng/api/networking/storage/IStorageGrid.java
@@ -1,0 +1,68 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.networking.storage;
+
+import appeng.api.networking.IGridCache;
+import appeng.api.networking.IGridHost;
+import appeng.api.networking.security.BaseActionSource;
+import appeng.api.storage.ICellContainer;
+import appeng.api.storage.ICellProvider;
+import appeng.api.storage.IStorageMonitorable;
+import appeng.api.storage.StorageChannel;
+import appeng.api.storage.data.IAEStack;
+
+/**
+ * Common base class for item / fluid storage caches.
+ */
+public interface IStorageGrid extends IGridCache, IStorageMonitorable
+{
+
+	/**
+	 * Used to inform the network of alterations to the storage system that fall outside of the standard Network
+	 * operations, Examples, ME Chest inputs from the world, or a Storage Bus detecting modifications made to the chest
+	 * by an outside force.
+	 * 
+	 * Expects the input to have either a negative or a positive stack size to correspond to the injection, or
+	 * extraction operation.
+	 * 
+	 * @param input injected items
+	 */
+	void postAlterationOfStoredItems(StorageChannel chan, Iterable<? extends IAEStack> input, BaseActionSource src);
+
+	/**
+	 * Used to add a cell provider to the storage system
+	 * 
+	 * THIS IT NOT FOR USE {@link IGridHost} THAT PROVIDE {@link ICellContainer} - those are automatically handled by
+	 * the storage system.
+	 * 
+	 * @param cc to be added cell provider
+	 */
+	void registerCellProvider(ICellProvider cc);
+
+	/**
+	 * remove a provider added with addCellContainer
+	 */
+	void unregisterCellProvider(ICellProvider cc);
+
+}

--- a/src/api/java/appeng/api/package-info.java
+++ b/src/api/java/appeng/api/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+@API(apiVersion = "rv2", owner = "appliedenergistics2", provides = "appliedenergistics2|API")
+package appeng.api;
+
+import cpw.mods.fml.common.API;
+

--- a/src/api/java/appeng/api/parts/BusSupport.java
+++ b/src/api/java/appeng/api/parts/BusSupport.java
@@ -1,0 +1,33 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.parts;
+
+public enum BusSupport
+{
+	CABLE,
+
+	DENSE_CABLE,
+
+	NO_PARTS
+}

--- a/src/api/java/appeng/api/parts/CableRenderMode.java
+++ b/src/api/java/appeng/api/parts/CableRenderMode.java
@@ -1,0 +1,40 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.parts;
+
+public enum CableRenderMode
+{
+
+	Standard(false),
+
+	CableView(true);
+
+	public final boolean transparentFacades;
+	public final boolean opaqueFacades;
+
+	private CableRenderMode(boolean hideFacades) {
+		this.transparentFacades = hideFacades;
+		opaqueFacades = !hideFacades;
+	}
+}

--- a/src/api/java/appeng/api/parts/IBoxProvider.java
+++ b/src/api/java/appeng/api/parts/IBoxProvider.java
@@ -1,0 +1,36 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.parts;
+
+public interface IBoxProvider
+{
+
+	/**
+	 * add your collision information to the the list.
+	 * 
+	 * @param boxes collision boxes
+	 */
+	void getBoxes(IPartCollisionHelper boxes);
+
+}

--- a/src/api/java/appeng/api/parts/IFacadeContainer.java
+++ b/src/api/java/appeng/api/parts/IFacadeContainer.java
@@ -1,0 +1,98 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.parts;
+
+import io.netty.buffer.ByteBuf;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.common.util.ForgeDirection;
+
+import java.io.IOException;
+
+/**
+ * Used Internally.
+ * 
+ * not intended for implementation.
+ */
+public interface IFacadeContainer
+{
+
+	/**
+	 * Attempts to add the {@link IFacadePart} to the given side.
+	 * 
+	 * @return true if the facade as successfully added.
+	 */
+	boolean addFacade(IFacadePart a);
+
+	/**
+	 * Removed the facade on the given side, or does nothing.
+	 */
+	void removeFacade(IPartHost host, ForgeDirection side);
+
+	/**
+	 * @return the {@link IFacadePart} for a given side, or null.
+	 */
+	IFacadePart getFacade(ForgeDirection s);
+
+	/**
+	 * rotate the facades left.
+	 */
+	void rotateLeft();
+
+	/**
+	 * write nbt data
+	 * 
+	 * @param data to be written data
+	 */
+	void writeToNBT(NBTTagCompound data);
+
+	/**
+	 * read from stream
+	 * 
+	 * @param data to be read data
+	 * @return true if it was readable
+	 * @throws IOException
+	 */
+	boolean readFromStream(ByteBuf data) throws IOException;
+
+	/**
+	 * read from NBT
+	 * 
+	 * @param data to be read data
+	 */
+	void readFromNBT(NBTTagCompound data);
+
+	/**
+	 * write to stream
+	 * 
+	 * @param data to be written data
+	 * @throws IOException
+	 */
+	void writeToStream(ByteBuf data) throws IOException;
+
+	/**
+	 * @return true if there are no facades.
+	 */
+	boolean isEmpty();
+
+}

--- a/src/api/java/appeng/api/parts/IFacadePart.java
+++ b/src/api/java/appeng/api/parts/IFacadePart.java
@@ -1,0 +1,100 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.parts;
+
+import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraft.entity.Entity;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.AxisAlignedBB;
+import net.minecraftforge.common.util.ForgeDirection;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+/**
+ * Used Internally.
+ * 
+ * not intended for implementation.
+ */
+public interface IFacadePart
+{
+
+	/**
+	 * used to save the part.
+	 */
+	ItemStack getItemStack();
+
+	/**
+	 * used to collide, and pick the part
+	 * 
+	 * @param ch collision helper
+	 * @param e colliding entity
+	 */
+	void getBoxes(IPartCollisionHelper ch, Entity e);
+
+	/**
+	 * render the part.
+	 * 
+	 * @param x x pos of part
+	 * @param y y pos of part
+	 * @param z z pos of part
+	 * @param instance render helper
+	 * @param renderer renderer
+	 * @param fc face container
+	 * @param busBounds bounding box
+	 * @param renderStilt if to render stilt
+	 */
+	@SideOnly(Side.CLIENT)
+	void renderStatic(int x, int y, int z, IPartRenderHelper instance, RenderBlocks renderer, IFacadeContainer fc, AxisAlignedBB busBounds, boolean renderStilt);
+
+	/**
+	 * render the part in inventory.
+	 * 
+	 * @param instance render helper
+	 * @param renderer renderer
+	 */
+	@SideOnly(Side.CLIENT)
+	void renderInventory(IPartRenderHelper instance, RenderBlocks renderer);
+
+	/**
+	 * @return side the facade is in
+	 */
+	ForgeDirection getSide();
+
+	/**
+	 * @return the box for the face of the facade
+	 */
+	AxisAlignedBB getPrimaryBox();
+
+	Item getItem();
+
+	int getItemDamage();
+
+	boolean isBC();
+
+	void setThinFacades(boolean useThinFacades);
+
+	boolean isTransparent();
+
+}

--- a/src/api/java/appeng/api/parts/IPart.java
+++ b/src/api/java/appeng/api/parts/IPart.java
@@ -1,0 +1,296 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.parts;
+
+import appeng.api.networking.IGridNode;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.IIcon;
+import net.minecraft.util.Vec3;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Random;
+
+public interface IPart extends IBoxProvider
+{
+
+	/**
+	 * get an ItemStack that represents the bus, should contain the settings for whatever, can also be used in
+	 * conjunction with removePart to take a part off and drop it or something.
+	 *
+	 * This is used to drop the bus, and to save the bus, when saving the bus, wrenched is false, and writeToNBT will be
+	 * called to save important details about the part, if the part is wrenched include in your NBT Data any settings
+	 * you might want to keep around, you can restore those settings when constructing your part.
+	 *
+	 * @param type , what kind of ItemStack to return?
+	 *
+	 * @return item of part
+	 */
+	ItemStack getItemStack(PartItemStack type);
+
+	/**
+	 * render item form for inventory, or entity.
+	 *
+	 * GL Available
+	 *
+	 * @param rh       helper
+	 * @param renderer renderer
+	 */
+	@SideOnly(Side.CLIENT)
+	void renderInventory(IPartRenderHelper rh, RenderBlocks renderer);
+
+	/**
+	 * render world renderer ( preferred )
+	 *
+	 * GL is NOT Available
+	 *
+	 * @param x x coord
+	 * @param y y coord
+	 * @param z z coord
+	 * @param rh helper
+	 * @param renderer renderer
+	 */
+	@SideOnly(Side.CLIENT)
+	void renderStatic(int x, int y, int z, IPartRenderHelper rh, RenderBlocks renderer);
+
+	/**
+	 * render TESR.
+	 *
+	 * GL Available
+	 *
+	 * @param x x coord
+	 * @param y y coord
+	 * @param z z coord
+	 * @param rh helper
+	 * @param renderer renderer
+	 */
+	@SideOnly(Side.CLIENT)
+	void renderDynamic(double x, double y, double z, IPartRenderHelper rh, RenderBlocks renderer);
+
+	/**
+	 * @return the Block sheet icon used when rendering the breaking particles, return null to use the ItemStack
+	 * texture.
+	 */
+	@SideOnly(Side.CLIENT)
+	IIcon getBreakingTexture();
+
+	/**
+	 * return true only if your part require dynamic rendering, must be consistent.
+	 *
+	 * @return true to enable renderDynamic
+	 */
+	boolean requireDynamicRender();
+
+	/**
+	 * @return if the bus has a solid side, and you can place random stuff on it like torches or levers
+	 */
+	boolean isSolid();
+
+	/**
+	 * @return true if this part can connect to redstone ( also MFR Rednet )
+	 */
+	boolean canConnectRedstone();
+
+	/**
+	 * Write the part information for saving, the part will be saved with getItemStack(false) and this method will be
+	 * called after to load settings, inventory or other values from the world.
+	 *
+	 * @param data to be written nbt data
+	 */
+	void writeToNBT(NBTTagCompound data);
+
+	/**
+	 * Read the previously written NBT Data. this is the mirror for writeToNBT
+	 *
+	 * @param data to be read nbt data
+	 */
+	void readFromNBT(NBTTagCompound data);
+
+	/**
+	 * @return get the amount of light produced by the bus
+	 */
+	int getLightLevel();
+
+	/**
+	 * does this part act like a ladder?
+	 *
+	 * @param entity climbing entity
+	 *
+	 * @return true if entity can climb
+	 */
+	boolean isLadder(EntityLivingBase entity);
+
+	/**
+	 * a block around the bus's host has been changed.
+	 */
+	void onNeighborChanged();
+
+	/**
+	 * @return output redstone on facing side
+	 */
+	int isProvidingStrongPower();
+
+	/**
+	 * @return output redstone on facing side
+	 */
+	int isProvidingWeakPower();
+
+	/**
+	 * write data to bus packet.
+	 *
+	 * @param data to be written data
+	 *
+	 * @throws IOException
+	 */
+	void writeToStream(ByteBuf data) throws IOException;
+
+	/**
+	 * read data from bus packet.
+	 *
+	 * @param data to be read data
+	 *
+	 * @return true will re-draw the part.
+	 *
+	 * @throws IOException
+	 */
+	boolean readFromStream(ByteBuf data) throws IOException;
+
+	/**
+	 * get the Grid Node for the Bus, be sure your IGridBlock is NOT isWorldAccessible, if it is your going to cause
+	 * crashes.
+	 *
+	 * or null if you don't have a grid node.
+	 *
+	 * @return grid node
+	 */
+	IGridNode getGridNode();
+
+	/**
+	 * called when an entity collides with the bus.
+	 *
+	 * @param entity colliding entity
+	 */
+	void onEntityCollision(Entity entity);
+
+	/**
+	 * called when your part is being removed from the world.
+	 */
+	void removeFromWorld();
+
+	/**
+	 * called when your part is being added to the world.
+	 */
+	void addToWorld();
+
+	/**
+	 * used for tunnels.
+	 *
+	 * @return a grid node that represents the external facing side, these must be isWorldAccessible with the correct
+	 * faces marked as external
+	 */
+	IGridNode getExternalFacingNode();
+
+	/**
+	 * called by the Part host to keep your part informed.
+	 *
+	 * @param host part side
+	 * @param tile tile entity of part
+	 */
+	void setPartHostInfo(ForgeDirection side, IPartHost host, TileEntity tile);
+
+	/**
+	 * Called when you right click the part, very similar to Block.onActivateBlock
+	 *
+	 * @param player right clicking player
+	 * @param pos position of block
+	 *
+	 * @return if your activate method performed something.
+	 */
+	boolean onActivate(EntityPlayer player, Vec3 pos);
+
+	/**
+	 * Called when you right click the part, very similar to Block.onActivateBlock
+	 *
+	 * @param player shift right clicking player
+	 * @param pos position of block
+	 *
+	 * @return if your activate method performed something, you should use false unless you really need it.
+	 */
+	boolean onShiftActivate(EntityPlayer player, Vec3 pos);
+
+	/**
+	 * Add drops to the items being dropped into the world, if your item stores its contents when wrenched use the
+	 * wrenched boolean to control what data is saved vs dropped when it is broken.
+	 *
+	 * @param drops item drops if wrenched
+	 * @param wrenched control flag for wrenched vs broken
+	 */
+	void getDrops(List<ItemStack> drops, boolean wrenched);
+
+	/**
+	 * @return 0 - 8, reasonable default 3-4, this controls the cable connection to the node.
+	 */
+	int cableConnectionRenderTo();
+
+	/**
+	 * same as Block.randomDisplayTick, for but parts.
+	 *
+	 * @param world world of block
+	 * @param x x coord of block
+	 * @param y y coord of block
+	 * @param z z coord of block
+	 * @param r random
+	 */
+	void randomDisplayTick(World world, int x, int y, int z, Random r);
+
+	/**
+	 * Called when placed in the world by a player, this happens before addWorld.
+	 *
+	 * @param player placing player
+	 * @param held held item
+	 * @param side placing side
+	 */
+	void onPlacement(EntityPlayer player, ItemStack held, ForgeDirection side);
+
+	/**
+	 * Used to determine which parts can be placed on what cables.
+	 *
+	 * @param what placed part
+	 *
+	 * @return true if the part can be placed on this support.
+	 */
+	boolean canBePlacedOn(BusSupport what);
+
+}

--- a/src/api/java/appeng/api/parts/IPartCollisionHelper.java
+++ b/src/api/java/appeng/api/parts/IPartCollisionHelper.java
@@ -1,0 +1,65 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.parts;
+
+import net.minecraftforge.common.util.ForgeDirection;
+
+public interface IPartCollisionHelper
+{
+
+	/**
+	 * add a collision box, expects 0.0 - 16.0 block coords.
+	 * 
+	 * No complaints about the size, I like using pixels :P
+	 * 
+	 * @param minX minimal x collision
+	 * @param minY minimal y collision
+	 * @param minZ minimal z collision
+	 * @param maxX maximal x collision
+	 * @param maxY maximal y collision
+	 * @param maxZ maximal z collision
+	 */
+	void addBox(double minX, double minY, double minZ, double maxX, double maxY, double maxZ);
+
+	/**
+	 * @return east in world space.
+	 */
+	ForgeDirection getWorldX();
+
+	/**
+	 * @return up in world space.
+	 */
+	ForgeDirection getWorldY();
+
+	/**
+	 * @return forward in world space.
+	 */
+	ForgeDirection getWorldZ();
+
+	/**
+	 * @return true if this test is to get the BB Collision information.
+	 */
+	boolean isBBCollision();
+
+}

--- a/src/api/java/appeng/api/parts/IPartHelper.java
+++ b/src/api/java/appeng/api/parts/IPartHelper.java
@@ -1,0 +1,84 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.parts;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+
+public interface IPartHelper
+{
+
+	/**
+	 * Register a new layer with the part layer system, this allows you to write
+	 * an in between between tile entities and parts.
+	 * 
+	 * AE By Default includes,
+	 * 
+	 * 1. ISidedInventory ( and by extension IInventory. )
+	 * 
+	 * 2. IFluidHandler Forge Fluids
+	 * 
+	 * 3. IPowerEmitter BC Power output.
+	 * 
+	 * 4. IPowerReceptor BC Power input.
+	 * 
+	 * 5. IEnergySink IC2 Power input.
+	 * 
+	 * 6. IEnergySource IC2 Power output.
+	 * 
+	 * 7. IPipeConnection BC Pipe Connections
+	 * 
+	 * As long as a valid layer is registered for a interface you can simply
+	 * implement that interface on a part get implement it.
+	 * 
+	 * @return true on success, false on failure, usually a error will be logged
+	 *         as well.
+	 */
+	boolean registerNewLayer(String string, String layerInterface);
+
+	/**
+	 * Register IBusItem with renderer
+	 */
+	void setItemBusRenderer(IPartItem i);
+
+	/**
+	 * use in use item, to try and place a IBusItem
+	 * 
+	 * @param is ItemStack of an item which implements {@link IPartItem}
+	 * @param x x pos of part
+	 * @param y y pos of part
+	 * @param z z pos of part
+	 * @param side side which the part should be on
+	 * @param player player placing part
+	 * @param world part in world
+	 * @return true if placing was successful
+	 */
+	boolean placeBus(ItemStack is, int x, int y, int z, int side, EntityPlayer player, World world);
+
+	/**
+	 * @return the render mode
+	 */
+	CableRenderMode getCableRenderMode();
+}

--- a/src/api/java/appeng/api/parts/IPartHost.java
+++ b/src/api/java/appeng/api/parts/IPartHost.java
@@ -1,0 +1,175 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.parts;
+
+import appeng.api.util.AEColor;
+import appeng.api.util.DimensionalCoord;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.Vec3;
+import net.minecraftforge.common.util.ForgeDirection;
+
+import java.util.Set;
+
+/**
+ * Implemented on AE's TileEntity or AE's FMP Part.
+ * 
+ * Do Not Implement
+ */
+public interface IPartHost
+{
+
+	/**
+	 * @return the facade container
+	 */
+	IFacadeContainer getFacadeContainer();
+
+	/**
+	 * Test if you can add a part to the specified side of the Part Host, {@link ForgeDirection}.UNKNOWN is used to
+	 * represent the cable in the middle.
+	 * 
+	 * @param part to be added part
+	 * @param side part placed onto side
+	 * @return returns false if the part cannot be added.
+	 */
+	boolean canAddPart(ItemStack part, ForgeDirection side);
+
+	/**
+	 * try to add a new part to the specified side, returns false if it failed to be added.
+	 * 
+	 * @param is new part
+	 * @param side onto side
+	 * @param owner with owning player
+	 * @return null if the item failed to add, the side it was placed on other wise ( may different for cables,
+	 *         {@link ForgeDirection}.UNKNOWN )
+	 */
+	ForgeDirection addPart(ItemStack is, ForgeDirection side, EntityPlayer owner);
+
+	/**
+	 * Get part by side ( center is {@link ForgeDirection}.UNKNOWN )
+	 * 
+	 * @param side side of part
+	 * @return the part located on the specified side, or null if there is no part.
+	 */
+	IPart getPart(ForgeDirection side);
+
+	/**
+	 * removes the part on the side, this doesn't drop it or anything, if you don't do something with it, its just
+	 * "gone" and its never coming back; think about it.
+	 * 
+	 * if you want to drop the part you must request it prior to removing it.
+	 * 
+	 * @param side side of part
+	 * @param suppressUpdate
+	 *            - used if you need to replace a part's instance, without really removing it first.
+	 */
+	void removePart(ForgeDirection side, boolean suppressUpdate);
+
+	/**
+	 * something changed, might want to send a packet to clients to update state.
+	 */
+	void markForUpdate();
+
+	/**
+	 * @return the physical location of the part host in the universe.
+	 */
+	DimensionalCoord getLocation();
+
+	/**
+	 * @return the tile entity for the host, this can either be an FMP tile, or a AE tile
+	 */
+	TileEntity getTile();
+
+	/**
+	 * @return the color of the host type ( this is determined by the middle cable. ) if no cable is present, it returns
+	 *         {@link AEColor} .Transparent other wise it returns the color of the cable in the center.
+	 */
+	AEColor getColor();
+
+	/**
+	 * destroys the part container, for internal use.
+	 */
+	void clearContainer();
+
+	/**
+	 * Used to test for FMP microblock blocking internally.
+	 * 
+	 * @return returns if microblocks are blocking this cable path.
+	 */
+	boolean isBlocked(ForgeDirection side);
+
+	/**
+	 * finds the part located at the position ( pos must be relative, not global )
+	 * 
+	 * @param pos part position
+	 * @return a new SelectedPart, this is never null.
+	 */
+	SelectedPart selectPart(Vec3 pos);
+
+	/**
+	 * can be used by parts to trigger the tile or part to save.
+	 */
+	void markForSave();
+
+	/**
+	 * part of the {@link LayerBase}
+	 */
+	void partChanged();
+
+	/**
+	 * get the redstone state of host on this side, this value is cached internally.
+	 * 
+	 * @param side side of part
+	 * @return true of the part host is receiving redstone from an external source.
+	 */
+	boolean hasRedstone(ForgeDirection side);
+
+	/**
+	 * returns false if this block contains any parts or facades, true other wise.
+	 */
+	boolean isEmpty();
+
+	/**
+	 * @return a mutable list of flags you can adjust to track state.
+	 */
+	Set<LayerFlags> getLayerFlags();
+
+	/**
+	 * remove host from world...
+	 */
+	void cleanup();
+
+	/**
+	 * notify neighbors uf updated status.
+	 */
+	void notifyNeighbors();
+
+	/**
+	 * true if the tile is in the world, other wise false.
+	 * 
+	 * @return true if tile is in world
+	 */
+	boolean isInWorld();
+}

--- a/src/api/java/appeng/api/parts/IPartItem.java
+++ b/src/api/java/appeng/api/parts/IPartItem.java
@@ -1,0 +1,65 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.parts;
+
+import net.minecraft.item.ItemStack;
+
+//@formatter:off
+/**
+ * This is a pretty basic requirement, once you implement the interface, and createPartFromItemStack
+ * 
+ * you must register your bus with the Bus renderer, using AEApi.instance().partHelper().setItemBusRenderer( this );
+ * 
+ * then simply add these two methods, which tell MC to use the Block Textures, and call AE's Bus Placement Code.
+ *
+ * <pre>
+ * <code>
+ * {@literal @}Override
+ * {@literal @}SideOnly(Side.CLIENT)
+ * public int getSpriteNumber()
+ * {
+ *     return 0;
+ * }
+ *
+ * {@literal @}Override
+ * public boolean onItemUse(ItemStack is, EntityPlayer player, World world, int x, int y, int z, int side, float hitX, float hitY, float hitZ)
+ * {
+ *     return AEApi.instance().partHelper().placeBus( is, x, y, z, side, player, world );
+ * }
+ * </code>
+ * </pre>
+ *
+ */
+public interface IPartItem
+{
+
+	/**
+	 * create a new part instance, from the item stack.
+	 * 
+	 * @param is item
+	 * @return part from item
+	 */
+	IPart createPartFromItemStack(ItemStack is);
+
+}

--- a/src/api/java/appeng/api/parts/IPartRenderHelper.java
+++ b/src/api/java/appeng/api/parts/IPartRenderHelper.java
@@ -1,0 +1,201 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.parts;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import net.minecraft.block.Block;
+import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraft.util.IIcon;
+import net.minecraftforge.common.util.ForgeDirection;
+
+import java.util.EnumSet;
+
+public interface IPartRenderHelper
+{
+
+	/**
+	 * sets the Render Helpers Block Bounds. 0.0 - 16.0 block coords.
+	 * 
+	 * No complaints about the size, I like using pixels :P
+	 * 
+	 * @param minX minimal x bound
+	 * @param minY minimal y bound
+	 * @param minZ minimal z bound
+	 * @param maxX maximal x bound
+	 * @param maxY maximal y bound
+	 * @param maxZ maximal z bound
+	 */
+	void setBounds(float minX, float minY, float minZ, float maxX, float maxY, float maxZ);
+
+	/**
+	 * static renderer
+	 * 
+	 * render a single face.
+	 * 
+	 * @param x x coord of part
+	 * @param y y coord of part
+	 * @param z z coord of part
+	 * @param ico icon of part
+	 * @param face direction its facing
+	 * @param renderer renderer of part
+	 */
+	@SideOnly(Side.CLIENT)
+	void renderFace(int x, int y, int z, IIcon ico, ForgeDirection face, RenderBlocks renderer);
+
+	/**
+	 * static renderer
+	 * 
+	 * render a box with a cut out box in the center.
+	 * 
+	 * @param x x pos of part
+	 * @param y y pos of part
+	 * @param z z pos of part
+	 * @param ico icon of part
+	 * @param face face of part
+	 * @param edgeThickness thickness of the edge
+	 * @param renderer renderer
+	 */
+	@SideOnly(Side.CLIENT)
+	void renderFaceCutout(int x, int y, int z, IIcon ico, ForgeDirection face, float edgeThickness, RenderBlocks renderer);
+
+	/**
+	 * static renderer
+	 * 
+	 * render a block of specified bounds.
+	 * 
+	 * @param x x pos of block
+	 * @param y y pos of block
+	 * @param z z pos of block
+	 * @param renderer renderer
+	 */
+	@SideOnly(Side.CLIENT)
+	void renderBlock(int x, int y, int z, RenderBlocks renderer);
+
+	/**
+	 * render a single face in inventory renderer.
+	 * 
+	 * @param IIcon icon of part
+	 * @param direction face of part
+	 * @param renderer renderer
+	 */
+	@SideOnly(Side.CLIENT)
+	void renderInventoryFace(IIcon IIcon, ForgeDirection direction, RenderBlocks renderer);
+
+	/**
+	 * render a box in inventory renderer.
+	 * 
+	 * @param renderer renderer
+	 */
+	@SideOnly(Side.CLIENT)
+	void renderInventoryBox(RenderBlocks renderer);
+
+	/**
+	 * inventory, and static renderer.
+	 * 
+	 * set unique icons for each side of the block.
+	 * 
+	 * @param down down face
+	 * @param up up face
+	 * @param north north face
+	 * @param south south face
+	 * @param west west face
+	 * @param east east face
+	 */
+	void setTexture(IIcon down, IIcon up, IIcon north, IIcon south, IIcon west, IIcon east);
+
+	/**
+	 * inventory, and static renderer.
+	 * 
+	 * set all sides to a single IIcon.
+	 * 
+	 * @param ico to be set icon
+	 */
+	void setTexture(IIcon ico);
+
+	/**
+	 * configure the color multiplier for the inventory renderer.
+	 * 
+	 * @param whiteVariant color multiplier
+	 */
+	void setInvColor(int whiteVariant);
+
+	/**
+	 * @return the block used for rendering, might need it for some reason...
+	 */
+	Block getBlock();
+
+	/**
+	 * @return the east vector in world directions, rather then renderer
+	 */
+	ForgeDirection getWorldX();
+
+	/**
+	 * @return the up vector in world directions, rather then renderer.
+	 */
+	ForgeDirection getWorldY();
+
+	/**
+	 * @return the forward vector in world directions, rather then renderer.
+	 */
+	ForgeDirection getWorldZ();
+
+	/**
+	 * Pre-Calculates default lighting for the part, call this before using the render helper to render anything else to
+	 * get simplified, but faster lighting for more then one block.
+	 * 
+	 * Only worth it if you render more then 1 block.
+	 */
+	ISimplifiedBundle useSimplifiedRendering(int x, int y, int z, IBoxProvider p, ISimplifiedBundle sim);
+
+	/**
+	 * disables, useSimplifiedRendering.
+	 */
+	void normalRendering();
+
+	/**
+	 * render a block using the current renderer state.
+	 * 
+	 * @param x x pos of part
+	 * @param y y pos of part
+	 * @param z z pos of part
+	 * @param renderer renderer of part
+	 */
+	void renderBlockCurrentBounds(int x, int y, int z, RenderBlocks renderer);
+
+	/**
+	 * allow you to enable your part to render during the alpha pass or the standard pass.
+	 * 
+	 * @param pass render pass
+	 */
+	void renderForPass(int pass);
+
+	/**
+	 * Set which faces to render, remember to set back to ALL when you are done.
+	 * 
+	 * @param complementOf sides to render
+	 */
+	void setFacesToRender(EnumSet<ForgeDirection> complementOf);
+
+}

--- a/src/api/java/appeng/api/parts/ISimplifiedBundle.java
+++ b/src/api/java/appeng/api/parts/ISimplifiedBundle.java
@@ -1,0 +1,30 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.parts;
+
+
+public interface ISimplifiedBundle
+{
+
+}

--- a/src/api/java/appeng/api/parts/LayerFlags.java
+++ b/src/api/java/appeng/api/parts/LayerFlags.java
@@ -1,0 +1,31 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.parts;
+
+public enum LayerFlags
+{
+
+	IC2_ENET
+
+}

--- a/src/api/java/appeng/api/parts/PartItemStack.java
+++ b/src/api/java/appeng/api/parts/PartItemStack.java
@@ -1,0 +1,37 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.parts;
+
+public enum PartItemStack
+{
+	Pick,
+
+	Break,
+
+	Wrench,
+
+	Network,
+
+	World
+}

--- a/src/api/java/appeng/api/parts/SelectedPart.java
+++ b/src/api/java/appeng/api/parts/SelectedPart.java
@@ -1,0 +1,67 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.parts;
+
+import net.minecraftforge.common.util.ForgeDirection;
+
+/**
+ * Reports a selected part from th IPartHost
+ */
+public class SelectedPart
+{
+
+	/**
+	 * selected part.
+	 */
+	public final IPart part;
+
+	/**
+	 * facade part.
+	 */
+	public final IFacadePart facade;
+
+	/**
+	 * side the part is mounted too, or {@link ForgeDirection}.UNKNOWN for cables.
+	 */
+	public final ForgeDirection side;
+
+	public SelectedPart() {
+		part = null;
+		facade = null;
+		side = ForgeDirection.UNKNOWN;
+	}
+
+	public SelectedPart(IPart part, ForgeDirection side) {
+		this.part = part;
+		facade = null;
+		this.side = side;
+	}
+
+	public SelectedPart(IFacadePart facade, ForgeDirection side) {
+		part = null;
+		this.facade = facade;
+		this.side = side;
+	}
+
+}

--- a/src/api/java/appeng/api/recipes/ICraftHandler.java
+++ b/src/api/java/appeng/api/recipes/ICraftHandler.java
@@ -1,0 +1,52 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.recipes;
+
+import appeng.api.exceptions.MissingIngredientError;
+import appeng.api.exceptions.RecipeError;
+import appeng.api.exceptions.RegistrationError;
+
+import java.util.List;
+
+public interface ICraftHandler
+{
+
+	/**
+	 * Called when your recipe handler receives a newly parsed list of inputs/outputs.
+	 * 
+	 * @param input parsed inputs
+	 * @param output parsed outputs
+	 * @throws RecipeError
+	 */
+	public void setup(List<List<IIngredient>> input, List<List<IIngredient>> output) throws RecipeError;
+
+	/**
+	 * called when all recipes are parsed, and your required to register your recipe.
+	 * 
+	 * @throws RegistrationError
+	 * @throws MissingIngredientError
+	 */
+	public void register() throws RegistrationError, MissingIngredientError;
+
+}

--- a/src/api/java/appeng/api/recipes/IIngredient.java
+++ b/src/api/java/appeng/api/recipes/IIngredient.java
@@ -1,0 +1,87 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.recipes;
+
+import net.minecraft.item.ItemStack;
+import appeng.api.exceptions.MissingIngredientError;
+import appeng.api.exceptions.RegistrationError;
+
+public interface IIngredient {
+
+	/**
+	 * Acquire a single input stack for the current recipe, if more then one ItemStack is possible a
+	 * RegistrationError exception will be thrown, ignore these and let the system handle the error.
+	 * 
+	 * @return a single ItemStack for the recipe handler.
+	 * 
+	 * @throws RegistrationError
+	 * @throws MissingIngredientError
+	 */
+	ItemStack getItemStack() throws RegistrationError, MissingIngredientError;
+
+	/**
+	 * Acquire a list of all the input stacks for the current recipe, this is for handlers that support
+	 * multiple inputs per slot.
+	 * 
+	 * @return an array of ItemStacks for the recipe handler.
+	 * @throws RegistrationError
+	 * @throws MissingIngredientError
+	 */
+	ItemStack[] getItemStackSet() throws RegistrationError, MissingIngredientError;
+
+	/**
+	 * If you wish to support air, you must test before getting the ItemStack, or ItemStackSet
+	 * 
+	 * @return true if this slot contains no ItemStack, this is passed as "_"
+	 */
+	public boolean isAir();
+	
+	/**
+	 * @return The Name Space of the item. Prefer getItemStack or getItemStackSet 
+	 */
+	public String getNameSpace();
+
+	/**
+	 * @return The Name of the item. Prefer getItemStack or getItemStackSet 
+	 */
+	public String getItemName();
+
+	/**
+	 * @return The Damage Value of the item. Prefer getItemStack or getItemStackSet 
+	 */
+	public int getDamageValue();
+
+	/**
+	 * @return The Damage Value of the item. Prefer getItemStack or getItemStackSet 
+	 */
+	public int getQty();
+
+	/**
+	 * Bakes the lists in for faster runtime lookups.
+	 * @throws MissingIngredientError 
+	 * @throws RegistrationError 
+	 */
+	void bake() throws RegistrationError, MissingIngredientError;
+
+}

--- a/src/api/java/appeng/api/recipes/IRecipeHandler.java
+++ b/src/api/java/appeng/api/recipes/IRecipeHandler.java
@@ -1,0 +1,45 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.recipes;
+
+/**
+ * Represents the AE2 Recipe Loading/Reading Class
+ */
+public interface IRecipeHandler
+{
+
+	/**
+	 * Call when you want to read recipes in from a file based on a loader
+	 * 
+	 * @param loader recipe loader
+	 * @param path path of file
+	 */
+	void parseRecipes(IRecipeLoader loader, String path);
+
+	/**
+	 * this loads the read recipes into minecraft, should be called in Init.
+	 */
+	void injectRecipes();
+
+}

--- a/src/api/java/appeng/api/recipes/IRecipeLoader.java
+++ b/src/api/java/appeng/api/recipes/IRecipeLoader.java
@@ -1,0 +1,33 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.recipes;
+
+import java.io.BufferedReader;
+
+public interface IRecipeLoader
+{
+
+	BufferedReader getFile(String s) throws Exception;
+
+}

--- a/src/api/java/appeng/api/recipes/ISubItemResolver.java
+++ b/src/api/java/appeng/api/recipes/ISubItemResolver.java
@@ -1,0 +1,36 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.recipes;
+
+public interface ISubItemResolver
+{
+
+	/**
+	 * @param namespace namespace of sub item
+	 * @param fullName name of sub item
+	 * @return either a ResolveResult, or a ResolverResultSet
+	 */
+	public Object resolveItemByName(String namespace, String fullName);
+
+}

--- a/src/api/java/appeng/api/storage/ICellContainer.java
+++ b/src/api/java/appeng/api/storage/ICellContainer.java
@@ -1,0 +1,41 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.storage;
+
+import appeng.api.networking.security.IActionHost;
+
+/**
+ * Represents a IGridhost that contributes to storage, such as a ME Chest, or ME Drive.
+ */
+public interface ICellContainer extends IActionHost, ICellProvider, ISaveProvider
+{
+
+	/**
+	 * tell the Cell container that this slot should blink, the slot number is relative to the
+	 * 
+	 * @param slot slot index
+	 */
+	void blinkCell(int slot);
+
+}

--- a/src/api/java/appeng/api/storage/ICellHandler.java
+++ b/src/api/java/appeng/api/storage/ICellHandler.java
@@ -1,0 +1,123 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.storage;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.IIcon;
+import appeng.api.implementations.tiles.IChestOrDrive;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+/**
+ * Registration record for {@link ICellRegistry}
+ */
+public interface ICellHandler
+{
+
+	/**
+	 * return true if the provided item is handled by your cell handler. ( AE May choose to skip this method, and just
+	 * request a handler )
+	 * 
+	 * @param is to be checked item
+	 * @return return true, if getCellHandler will not return null.
+	 */
+	boolean isCell(ItemStack is);
+
+	/**
+	 * If you cannot handle the provided item, return null
+	 * 
+	 * @param is
+	 *            a storage cell item.
+	 * @param host
+	 *            anytime the contents of your storage cell changes it should use this to request a save, please
+	 *            note, this value can be null.
+	 * @param channel
+	 *            the storage channel requested.
+	 * 
+	 * @return a new IMEHandler for the provided item
+	 */
+	IMEInventoryHandler getCellInventory(ItemStack is, ISaveProvider host, StorageChannel channel);
+
+	/**
+	 * @return the ME Chest texture for light pixels this storage cell type, should be 10x10 with 3px of transparent
+	 *         padding on a 16x16 texture, null is valid if your cell cannot be used in the ME Chest. refer to the
+	 *         assets for examples.
+	 */
+	@SideOnly(Side.CLIENT)
+	IIcon getTopTexture_Light();
+
+	/**
+	 * @return the ME Chest texture for medium pixels this storage cell type, should be 10x10 with 3px of transparent
+	 *         padding on a 16x16 texture, null is valid if your cell cannot be used in the ME Chest. refer to the
+	 *         assets for examples.
+	 */
+	@SideOnly(Side.CLIENT)
+	IIcon getTopTexture_Medium();
+
+	/**
+	 * @return the ME Chest texture for dark pixels this storage cell type, should be 10x10 with 3px of transparent
+	 *         padding on a 16x16 texture, null is valid if your cell cannot be used in the ME Chest. refer to the
+	 *         assets for examples.
+	 */
+	@SideOnly(Side.CLIENT)
+	IIcon getTopTexture_Dark();
+
+	/**
+	 * 
+	 * Called when the storage cell is planed in an ME Chest and the user tries to open the terminal side, if your item
+	 * is not available via ME Chests simply tell the user they can't use it, or something, other wise you should open
+	 * your gui and display the cell to the user.
+	 * 
+	 * @param player player opening chest gui
+	 * @param chest to be opened chest
+	 * @param cellHandler cell handler
+	 * @param inv inventory handler
+	 * @param is item
+	 * @param chan storage channel
+	 */
+	void openChestGui(EntityPlayer player, IChestOrDrive chest, ICellHandler cellHandler, IMEInventoryHandler inv, ItemStack is, StorageChannel chan);
+
+	/**
+	 * 0 - cell is missing.
+	 * 
+	 * 1 - green, ( usually means available room for types or items. )
+	 * 
+	 * 2 - orange, ( usually means available room for items, but not types. )
+	 * 
+	 * 3 - red, ( usually means the cell is 100% full )
+	 * 
+	 * @param is the cell item. ( use the handler for any details you can )
+	 * @param handler the handler for the cell is provides for reference, you can cast this to your handler.
+	 * 
+	 * @return get the status of the cell based on its contents.
+	 */
+	int getStatusForCell(ItemStack is, IMEInventory handler);
+
+	/**
+	 * @return the ae/t to drain for this storage cell inside a chest/drive.
+	 */
+	double cellIdleDrain(ItemStack is, IMEInventory handler);
+
+}

--- a/src/api/java/appeng/api/storage/ICellProvider.java
+++ b/src/api/java/appeng/api/storage/ICellProvider.java
@@ -1,0 +1,52 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.storage;
+
+import java.util.List;
+
+/**
+ * Allows you to provide cells via non IGridHosts directly to the storage system, drives, and similar features should go
+ * though {@link ICellContainer} and be automatically handled by the storage system.
+ */
+public interface ICellProvider
+{
+
+	/**
+	 * Inventory of the tile for use with ME, should always return an valid list, never NULL.
+	 * 
+	 * You must return the correct Handler for the correct channel, if your handler returns a IAEItemStack handler, for
+	 * a Fluid Channel stuffs going to explode, same with the reverse.
+	 * 
+	 * @return a valid list of handlers, NEVER NULL
+	 */
+	List<IMEInventoryHandler> getCellArray(StorageChannel channel);
+
+	/**
+	 * the storage's priority.
+	 * 
+	 * Positive and negative are supported
+	 */
+	int getPriority();
+
+}

--- a/src/api/java/appeng/api/storage/ICellRegistry.java
+++ b/src/api/java/appeng/api/storage/ICellRegistry.java
@@ -1,0 +1,73 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.storage;
+
+import net.minecraft.item.ItemStack;
+import appeng.api.IAppEngApi;
+
+/**
+ * Storage Cell Registry, used for specially implemented cells, if you just want to make a item act like a cell, or new
+ * cell with different bytes, then you should probably consider IStorageCell instead its considerably simpler.
+ * 
+ * Do not Implement, obtained via {@link IAppEngApi}.getCellRegistry()
+ */
+public interface ICellRegistry
+{
+
+	/**
+	 * Register a new handler.
+	 * 
+	 * @param handler cell handler
+	 */
+	void addCellHandler(ICellHandler handler);
+
+	/**
+	 * return true, if you can get a InventoryHandler for the item passed.
+	 * 
+	 * @param is to be checked item
+	 * @return true if the provided item, can be handled by a handler in AE, ( AE May choose to skip this and just get
+	 *         the handler instead. )
+	 */
+	boolean isCellHandled(ItemStack is);
+
+	/**
+	 * get the handler, for the requested type.
+	 * 
+	 * @param is to be checked item
+	 * @return the handler registered for this item type.
+	 */
+	ICellHandler getHandler(ItemStack is);
+
+	/**
+	 * returns an IMEInventoryHandler for the provided item.
+	 * 
+	 * @param is item with inventory handler
+	 * @param host can be null, or the hosting tile / part.
+	 * @param chan the storage channel to request the handler for.
+	 * 
+	 * @return new IMEInventoryHandler, or null if there isn't one.
+	 */
+	IMEInventoryHandler getCellInventory(ItemStack is, ISaveProvider host, StorageChannel chan);
+
+}

--- a/src/api/java/appeng/api/storage/IExternalStorageHandler.java
+++ b/src/api/java/appeng/api/storage/IExternalStorageHandler.java
@@ -1,0 +1,60 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.storage;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.ForgeDirection;
+import appeng.api.networking.security.BaseActionSource;
+
+/**
+ * A Registration Record for {@link IExternalStorageRegistry}
+ */
+public interface IExternalStorageHandler
+{
+
+	/**
+	 * if this can handle the provided inventory, return true. ( Generally skipped by AE, and it just calls getInventory
+	 * )
+	 * 
+	 * @param te to be handled tile entity
+	 * @param mySrc source
+	 * @return true, if it can get a handler via getInventory
+	 */
+	boolean canHandle(TileEntity te, ForgeDirection d, StorageChannel channel, BaseActionSource mySrc);
+
+	/**
+	 * if this can handle the given inventory, return the a IMEInventory implementing class for it, if not return null
+	 * 
+	 * please note that if your inventory changes and requires polling, you must use an {@link IMEMonitor} instead of an
+	 * {@link IMEInventory} failure to do so will result in invalid item counts and reporting of the inventory.
+	 * 
+	 * @param te to be handled tile entity
+	 * @param d direction
+	 * @param channel channel
+	 * @param src source
+	 * @return The Handler for the inventory
+	 */
+	IMEInventory getInventory(TileEntity te, ForgeDirection d, StorageChannel channel, BaseActionSource src);
+
+}

--- a/src/api/java/appeng/api/storage/IExternalStorageRegistry.java
+++ b/src/api/java/appeng/api/storage/IExternalStorageRegistry.java
@@ -1,0 +1,55 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.storage;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.ForgeDirection;
+import appeng.api.IAppEngApi;
+import appeng.api.networking.security.BaseActionSource;
+
+/**
+ * A Registry of External Storage handlers.
+ * 
+ * Do not implement obtain via {@link IAppEngApi}.registries().getExternalStorageRegistry()
+ */
+public interface IExternalStorageRegistry
+{
+
+	/**
+	 * A registry for StorageBus interactions
+	 * 
+	 * @param esh storage handler
+	 */
+	void addExternalStorageInterface(IExternalStorageHandler esh);
+
+	/**
+	 * @param te tile entity
+	 * @param opposite direction
+	 * @param channel channel
+	 * @param mySrc source
+	 * @return the handler for a given tile / forge direction
+	 */
+	IExternalStorageHandler getHandler(TileEntity te, ForgeDirection opposite, StorageChannel channel, BaseActionSource mySrc);
+
+}

--- a/src/api/java/appeng/api/storage/IMEInventory.java
+++ b/src/api/java/appeng/api/storage/IMEInventory.java
@@ -1,0 +1,79 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.storage;
+
+import appeng.api.config.Actionable;
+import appeng.api.networking.security.BaseActionSource;
+import appeng.api.storage.data.IAEStack;
+import appeng.api.storage.data.IItemList;
+
+/**
+ * AE's Equivalent to IInventory, used to reading contents, and manipulating contents of ME Inventories.
+ * 
+ * Implementations should COMPLETELY ignore stack size limits from an external view point, Meaning that you can inject
+ * Integer.MAX_VALUE items and it should work as defined, or be able to extract Integer.MAX_VALUE and have it work as
+ * defined, Translations to MC's max stack size are external to the AE API.
+ * 
+ * If you want to request a stack of an item, you should should determine that prior to requesting the stack from the
+ * inventory.
+ */
+public interface IMEInventory<StackType extends IAEStack>
+{
+
+	/**
+	 * Store new items, or simulate the addition of new items into the ME Inventory.
+	 * 
+	 * @param input item to add.
+	 * @param type action type
+	 * @param src action source
+	 * @return returns the number of items not added.
+	 */
+	public StackType injectItems(StackType input, Actionable type, BaseActionSource src);
+
+	/**
+	 * Extract the specified item from the ME Inventory
+	 * 
+	 * @param request
+	 *            item to request ( with stack size. )
+	 * @param mode
+	 *            simulate, or perform action?
+	 * @return returns the number of items extracted, null
+	 */
+	public StackType extractItems(StackType request, Actionable mode, BaseActionSource src);
+
+	/**
+	 * request a full report of all available items, storage.
+	 * 
+	 * @param out
+	 *            the IItemList the results will be written too
+	 * @return returns same list that was passed in, is passed out
+	 */
+	public IItemList<StackType> getAvailableItems(IItemList<StackType> out);
+
+	/**
+	 * @return the type of channel your handler should be part of
+	 */
+	public StorageChannel getChannel();
+
+}

--- a/src/api/java/appeng/api/storage/IMEInventoryHandler.java
+++ b/src/api/java/appeng/api/storage/IMEInventoryHandler.java
@@ -1,0 +1,90 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.storage;
+
+import appeng.api.config.AccessRestriction;
+import appeng.api.storage.data.IAEStack;
+
+/**
+ * Thin logic layer that can be swapped with different IMEInventory implementations, used to handle features related to
+ * storage, that are Separate from the storage medium itself.
+ * 
+ * @param <StackType>
+ */
+public interface IMEInventoryHandler<StackType extends IAEStack> extends IMEInventory<StackType>
+{
+
+	/**
+	 * determine if items can be injected/extracted.
+	 * 
+	 * @return the access
+	 */
+	public AccessRestriction getAccess();
+
+	/**
+	 * determine if a particular item is prioritized for this inventory handler, if it is, then it will be added to this
+	 * inventory prior to any non-prioritized inventories.
+	 * 
+	 * @param input
+	 *            - item that might be added
+	 * @return if its prioritized
+	 */
+	public boolean isPrioritized(StackType input);
+
+	/**
+	 * determine if an item can be accepted and stored.
+	 * 
+	 * @param input
+	 *            - item that might be added
+	 * @return if the item can be added
+	 */
+	public boolean canAccept(StackType input);
+
+	/**
+	 * determine what the priority of the inventory is.
+	 * 
+	 * @return the priority, zero is default, positive and negative are supported.
+	 */
+	public int getPriority();
+
+	/**
+	 * pass back value for blinkCell.
+	 * 
+	 * @return the slot index for the cell that this represents in the storage unit, the method on the
+	 *         {@link ICellContainer} will be called with this value, only trust the return value of this method if you
+	 *         are the implementer of the {@link IMEInventoryHandler}.
+	 */
+	public int getSlot();
+
+	/**
+	 * AE Uses a two pass placement system, the first pass checks contents and tries to find a place where the item
+	 * belongs, however in some cases you can save processor time, or require that the second, or first pass is simply
+	 * ignored, this allows you to do that.
+	 * 
+	 * @param i
+	 *            - pass number ( 1 or 2 )
+	 * @return true, if this inventory is valid for this pass.
+	 */
+	public boolean validForPass(int i);
+}

--- a/src/api/java/appeng/api/storage/IMEMonitor.java
+++ b/src/api/java/appeng/api/storage/IMEMonitor.java
@@ -1,0 +1,47 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.storage;
+
+import appeng.api.networking.storage.IBaseMonitor;
+import appeng.api.storage.data.IAEStack;
+import appeng.api.storage.data.IItemList;
+
+public interface IMEMonitor<T extends IAEStack> extends IMEInventoryHandler<T>, IBaseMonitor<T>
+{
+
+	@Override
+	@Deprecated
+	/**
+	 * This method is discouraged when accessing data via a IMEMonitor
+	 */
+	public IItemList<T> getAvailableItems(IItemList out);
+
+	/**
+	 * Get access to the full item list of the network, preferred over {@link IMEInventory} .getAvailableItems(...)
+	 * 
+	 * @return full storage list.
+	 */
+	IItemList<T> getStorageList();
+
+}

--- a/src/api/java/appeng/api/storage/IMEMonitorHandlerReceiver.java
+++ b/src/api/java/appeng/api/storage/IMEMonitorHandlerReceiver.java
@@ -1,0 +1,53 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.storage;
+
+import appeng.api.networking.security.BaseActionSource;
+import appeng.api.networking.storage.IBaseMonitor;
+import appeng.api.storage.data.IAEStack;
+
+public interface IMEMonitorHandlerReceiver<StackType extends IAEStack>
+{
+
+	/**
+	 * return true if this object should remain as a listener.
+	 * 
+	 * @param verificationToken to be checked object
+	 * @return true if object should remain as a listener
+	 */
+	boolean isValid(Object verificationToken);
+
+	/**
+	 * called when changes are made to the Monitor, but only if listener is still valid.
+	 * 
+	 * @param change done change
+	 */
+	void postChange(IBaseMonitor<StackType> monitor, Iterable<StackType> change, BaseActionSource actionSource);
+
+	/**
+	 * called when the list updates its contents, this is mostly for handling power events.
+	 */
+	void onListUpdate();
+
+}

--- a/src/api/java/appeng/api/storage/ISaveProvider.java
+++ b/src/api/java/appeng/api/storage/ISaveProvider.java
@@ -1,0 +1,32 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.storage;
+
+
+public interface ISaveProvider
+{
+
+	void saveChanges(IMEInventory cellInventory);
+
+}

--- a/src/api/java/appeng/api/storage/IStorageHelper.java
+++ b/src/api/java/appeng/api/storage/IStorageHelper.java
@@ -1,0 +1,117 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.storage;
+
+import appeng.api.networking.crafting.ICraftingLink;
+import appeng.api.networking.crafting.ICraftingRequester;
+import appeng.api.networking.energy.IEnergySource;
+import appeng.api.networking.security.BaseActionSource;
+import appeng.api.storage.data.IAEFluidStack;
+import appeng.api.storage.data.IAEItemStack;
+import appeng.api.storage.data.IItemList;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.fluids.FluidStack;
+
+import java.io.IOException;
+
+public interface IStorageHelper
+{
+
+	/**
+	 * load a crafting link from nbt data.
+	 * 
+	 * @param data to be loaded data
+	 * @return crafting link
+	 */
+	ICraftingLink loadCraftingLink(NBTTagCompound data, ICraftingRequester req);
+
+	/**
+	 * @param is
+	 *            An ItemStack
+	 * 
+	 * @return a new instance of {@link IAEItemStack} from a MC {@link ItemStack}
+	 */
+	IAEItemStack createItemStack(ItemStack is);
+
+	/**
+	 * @param is
+	 *            A FluidStack
+	 * 
+	 * @return a new instance of {@link IAEFluidStack} from a Forge {@link FluidStack}
+	 */
+	IAEFluidStack createFluidStack(FluidStack is);
+
+	/**
+	 * @return a new instance of {@link IItemList} for items
+	 */
+	IItemList<IAEItemStack> createItemList();
+
+	/**
+	 * @return a new instance of {@link IItemList} for fluids
+	 */
+	IItemList<IAEFluidStack> createFluidList();
+
+	/**
+	 * Read a AE Item Stack from a byte stream, returns a AE item stack or null.
+	 * 
+	 * @param input to be loaded data
+	 * @return item based of data
+	 * @throws IOException if file could not be read
+	 */
+	IAEItemStack readItemFromPacket(ByteBuf input) throws IOException;
+
+	/**
+	 * Read a AE Fluid Stack from a byte stream, returns a AE fluid stack or null.
+	 * 
+	 * @param input to be loaded data
+	 * @return fluid based on data
+	 * @throws IOException if file could not be written
+	 */
+	IAEFluidStack readFluidFromPacket(ByteBuf input) throws IOException;
+
+	/**
+	 * use energy from energy, to remove request items from cell, at the request of src.
+	 * 
+	 * @param energy to be drained energy source
+	 * @param cell cell of requested items
+	 * @param request requested items
+	 * @param src action source
+	 * @return items that successfully extracted.
+	 */
+	IAEItemStack poweredExtraction(IEnergySource energy, IMEInventory<IAEItemStack> cell, IAEItemStack request, BaseActionSource src);
+
+	/**
+	 * use energy from energy, to inject input items into cell, at the request of src
+	 * 
+	 * @param energy to be added energy source
+	 * @param cell injected cell
+	 * @param input to be injected items
+	 * @param src action source
+	 * @return items that failed to insert.
+	 */
+	IAEItemStack poweredInsert(IEnergySource energy, IMEInventory<IAEItemStack> cell, IAEItemStack input, BaseActionSource src);
+
+}

--- a/src/api/java/appeng/api/storage/IStorageMonitorable.java
+++ b/src/api/java/appeng/api/storage/IStorageMonitorable.java
@@ -1,0 +1,48 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.storage;
+
+import appeng.api.implementations.tiles.ITileStorageMonitorable;
+import appeng.api.storage.data.IAEFluidStack;
+import appeng.api.storage.data.IAEItemStack;
+
+/**
+ * represents the internal behavior of a {@link ITileStorageMonitorable} use it to get this value for a tile, or part.
+ * 
+ * never check a tile for this, always go though ITileStorageMonitorable if you wish to use this interface.
+ */
+public interface IStorageMonitorable
+{
+
+	/**
+	 * Access the item inventory for the monitorable storage.
+	 */
+	IMEMonitor<IAEItemStack> getItemInventory();
+
+	/**
+	 * Access the fluid inventory for the monitorable storage.
+	 */
+	IMEMonitor<IAEFluidStack> getFluidInventory();
+
+}

--- a/src/api/java/appeng/api/storage/StorageChannel.java
+++ b/src/api/java/appeng/api/storage/StorageChannel.java
@@ -1,0 +1,56 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.storage;
+
+import appeng.api.AEApi;
+import appeng.api.storage.data.IAEFluidStack;
+import appeng.api.storage.data.IAEItemStack;
+import appeng.api.storage.data.IAEStack;
+import appeng.api.storage.data.IItemList;
+
+public enum StorageChannel
+{
+	/**
+	 * AE2's Default Storage.
+	 */
+	ITEMS( IAEItemStack.class ),
+
+	/**
+	 * AE2's Fluid Based Storage ( mainly added to better support ExtraCells )
+	 */
+	FLUIDS( IAEFluidStack.class );
+	
+	public final Class<? extends IAEStack> type;
+
+	private StorageChannel( Class<? extends IAEStack> t ) {
+		type = t;
+	}
+
+	public IItemList createList() {
+		if ( this == ITEMS )
+			return AEApi.instance().storage().createItemList();
+		else
+			return AEApi.instance().storage().createFluidList();
+	}
+}

--- a/src/api/java/appeng/api/storage/data/IAEFluidStack.java
+++ b/src/api/java/appeng/api/storage/data/IAEFluidStack.java
@@ -1,0 +1,75 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.storage.data;
+
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidStack;
+
+/**
+ * An alternate version of FluidStack for AE to keep tabs on things easier, and
+ * to support larger storage. stackSizes of getFluidStack will be capped.
+ * 
+ * You may hold on to these if you want, just make sure you let go of them when
+ * your not using them.
+ *
+ * Don't Implement.
+ * 
+ * Construct with Util.createFluidStack( FluidStack )
+ * 
+ */
+public interface IAEFluidStack extends IAEStack<IAEFluidStack>
+{
+
+	/**
+	 * creates a standard Forge FluidStack for the fluid.
+	 * 
+	 * @return new FluidStack
+	 */
+	FluidStack getFluidStack();
+
+	/**
+	 * create a AE Fluid clone.
+	 * 
+	 * @return the copy.
+	 */
+	@Override
+	public IAEFluidStack copy();
+
+	/**
+	 * Combines two IAEItemStacks via addition.
+	 * 
+	 * @param option
+	 *            , to add to the current one.
+	 */
+	@Override
+	void add(IAEFluidStack option);
+
+	/**
+	 * quick way to get access to the Forge Fluid Definition.
+	 * 
+	 * @return fluid definition
+	 */
+	Fluid getFluid();
+
+}

--- a/src/api/java/appeng/api/storage/data/IAEItemStack.java
+++ b/src/api/java/appeng/api/storage/data/IAEItemStack.java
@@ -1,0 +1,105 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.storage.data;
+
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+
+/**
+ * An alternate version of ItemStack for AE to keep tabs on things easier, and to support larger storage. stackSizes of
+ * getItemStack will be capped.
+ * 
+ * You may hold on to these if you want, just make sure you let go of them when your not using them.
+ * 
+ * Don't Implement.
+ * 
+ * Construct with Util.createItemStack( ItemStack )
+ */
+public interface IAEItemStack extends IAEStack<IAEItemStack>
+{
+
+	/**
+	 * creates a standard MC ItemStack for the item.
+	 * 
+	 * @return new ItemStack
+	 */
+	public ItemStack getItemStack();
+
+	/**
+	 * create a AE Item clone
+	 * 
+	 * @return the copy
+	 */
+	@Override
+	public IAEItemStack copy();
+
+	/**
+	 * is there NBT Data for this item?
+	 * 
+	 * @return if there is
+	 */
+	boolean hasTagCompound();
+
+	/**
+	 * Combines two IAEItemStacks via addition.
+	 * 
+	 * @param option
+	 *            to add to the current one.
+	 */
+	@Override
+	void add(IAEItemStack option);
+
+	/**
+	 * quick way to get access to the MC Item Definition.
+	 * 
+	 * @return item definition
+	 */
+	Item getItem();
+
+	/**
+	 * @return the items damage value
+	 */
+	int getItemDamage();
+
+	/**
+	 * Compare the Ore Dictionary ID for this to another item.
+	 */
+	boolean sameOre(IAEItemStack is);
+
+	/**
+	 * compare the item/damage/nbt of the stack.
+	 * 
+	 * @param otherStack to be compared item
+	 * @return true if it is the same type (same item, damage, nbt)
+	 */
+	boolean isSameType(IAEItemStack otherStack);
+
+	/**
+	 * compare the item/damage/nbt of the stack.
+	 * 
+	 * @param stored to be compared item
+	 * @return true if it is the same type (same item, damage, nbt)
+	 */
+	boolean isSameType(ItemStack stored);
+}

--- a/src/api/java/appeng/api/storage/data/IAEStack.java
+++ b/src/api/java/appeng/api/storage/data/IAEStack.java
@@ -1,0 +1,201 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.storage.data;
+
+import appeng.api.config.FuzzyMode;
+import appeng.api.storage.StorageChannel;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.nbt.NBTTagCompound;
+
+import java.io.IOException;
+
+public interface IAEStack<StackType extends IAEStack>
+{
+
+	/**
+	 * add two stacks together
+	 * 
+	 * @param is added item
+	 */
+	void add(StackType is);
+
+	/**
+	 * number of items in the stack.
+	 * 
+	 * @return basically ItemStack.stackSize
+	 */
+	long getStackSize();
+
+	/**
+	 * changes the number of items in the stack.
+	 * 
+	 * @param stackSize
+	 *            , ItemStack.stackSize = N
+	 */
+	StackType setStackSize(long stackSize);
+
+	/**
+	 * Same as getStackSize, but for requestable items. ( LP )
+	 * 
+	 * @return basically itemStack.stackSize but for requestable items.
+	 */
+	long getCountRequestable();
+
+	/**
+	 * Same as setStackSize, but for requestable items. ( LP )
+	 * 
+	 * @return basically itemStack.stackSize = N but for setStackSize items.
+	 */
+	StackType setCountRequestable(long countRequestable);
+
+	/**
+	 * true, if the item can be crafted.
+	 * 
+	 * @return true, if it can be crafted.
+	 */
+	boolean isCraftable();
+
+	/**
+	 * change weather the item can be crafted.
+	 * 
+	 * @param isCraftable can item be crafted
+	 */
+	StackType setCraftable(boolean isCraftable);
+
+	/**
+	 * clears, requestable, craftable, and stack sizes.
+	 */
+	StackType reset();
+
+	/**
+	 * returns true, if the item can be crafted, requested, or extracted.
+	 * 
+	 * @return isThisRecordMeaningful
+	 */
+	boolean isMeaningful();
+
+	/**
+	 * Adds more to the stack size...
+	 * 
+	 * @param i additional stack size
+	 */
+	void incStackSize(long i);
+
+	/**
+	 * removes some from the stack size.
+	 */
+	void decStackSize(long i);
+
+	/**
+	 * adds items to the requestable
+	 * 
+	 * @param i increased amount of requested items
+	 */
+	void incCountRequestable(long i);
+
+	/**
+	 * removes items from the requestable
+	 * 
+	 * @param i decreased amount of requested items
+	 */
+	void decCountRequestable(long i);
+
+	/**
+	 * write to a NBTTagCompound.
+	 * 
+	 * @param i to be written data
+	 */
+	void writeToNBT(NBTTagCompound i);
+
+	/**
+	 * Compare stacks using precise logic.
+	 * 
+	 * a IAEItemStack to another AEItemStack or a ItemStack.
+	 * 
+	 * or
+	 * 
+	 * IAEFluidStack, FluidStack
+	 * 
+	 * @param obj compared object
+	 * @return true if they are the same.
+	 */
+	@Override
+	boolean equals(Object obj);
+
+	/**
+	 * compare stacks using fuzzy logic
+	 * 
+	 * a IAEItemStack to another AEItemStack or a ItemStack.
+	 * 
+	 * @param st stacks
+	 * @param mode used fuzzy mode
+	 * @return true if two stacks are equal based on AE Fuzzy Comparison.
+	 */
+	boolean fuzzyComparison(Object st, FuzzyMode mode);
+
+	/**
+	 * Slower for disk saving, but smaller/more efficient for packets.
+	 * 
+	 * @param data to be written data
+	 * @throws IOException
+	 */
+	void writeToPacket(ByteBuf data) throws IOException;
+
+	/**
+	 * Clone the Item / Fluid Stack
+	 * 
+	 * @return a new Stack, which is copied from the original.
+	 */
+	StackType copy();
+
+	/**
+	 * create an empty stack.
+	 * 
+	 * @return a new stack, which represents an empty copy of the original.
+	 */
+	StackType empty();
+
+	/**
+	 * obtain the NBT Data for the item.
+	 * 
+	 * @return nbt data
+	 */
+	IAETagCompound getTagCompound();
+
+	/**
+	 * @return true if the stack is a {@link IAEItemStack}
+	 */
+	boolean isItem();
+
+	/**
+	 * @return true if the stack is a {@link IAEFluidStack}
+	 */
+	boolean isFluid();
+
+	/**
+	 * @return ITEM or FLUID
+	 */
+	StorageChannel getChannel();
+
+}

--- a/src/api/java/appeng/api/storage/data/IAETagCompound.java
+++ b/src/api/java/appeng/api/storage/data/IAETagCompound.java
@@ -1,0 +1,56 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.storage.data;
+
+import net.minecraft.nbt.NBTTagCompound;
+import appeng.api.features.IItemComparison;
+
+/**
+ * Don't cast this... either compare with it, or copy it.
+ * 
+ * Don't Implement.
+ */
+public interface IAETagCompound
+{
+
+	/**
+	 * @return a copy ( the copy will not be a IAETagCompound, it will be a NBTTagCompound )
+	 */
+	public NBTTagCompound getNBTTagCompoundCopy();
+
+	/**
+	 * compare to other NBTTagCompounds or IAETagCompounds
+	 * 
+	 * @param a compared object
+	 * @return true, if they are the same.
+	 */
+	@Override
+	boolean equals(Object a);
+
+	/**
+	 * @return the special comparison for this tag
+	 */
+	IItemComparison getSpecialComparison();
+
+}

--- a/src/api/java/appeng/api/storage/data/IItemContainer.java
+++ b/src/api/java/appeng/api/storage/data/IItemContainer.java
@@ -1,0 +1,65 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.storage.data;
+
+import appeng.api.config.FuzzyMode;
+
+import java.util.Collection;
+
+/**
+ * Represents a list of items in AE.
+ * 
+ * Don't Implement.
+ * 
+ * Construct with Util.createItemList()
+ */
+public interface IItemContainer<StackType extends IAEStack>
+{
+
+	/**
+	 * add a stack to the list, this will merge the stack with an item already in the list if found.
+	 * 
+	 * @param option added stack
+	 */
+	public void add(StackType option); // adds stack as is
+
+	/**
+	 * @param i compared item
+	 * @return a stack equivalent to the stack passed in, but with the correct stack size information, or null if its
+	 *         not present
+	 */
+	StackType findPrecise(StackType i);
+
+	/**
+	 * @param input compared item
+	 * @return a list of relevant fuzzy matched stacks
+	 */
+	public Collection<StackType> findFuzzy(StackType input, FuzzyMode fuzzy);
+
+	/**
+	 * @return true if there are no items in the list
+	 */
+	public boolean isEmpty();
+
+}

--- a/src/api/java/appeng/api/storage/data/IItemList.java
+++ b/src/api/java/appeng/api/storage/data/IItemList.java
@@ -1,0 +1,82 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.storage.data;
+
+import java.util.Iterator;
+
+/**
+ * Represents a list of items in AE.
+ * 
+ * Don't Implement.
+ * 
+ * Construct with Util.createItemList()
+ */
+public interface IItemList<StackType extends IAEStack> extends IItemContainer<StackType>, Iterable<StackType>
+{
+
+	/**
+	 * add a stack to the list stackSize is used to add to stackSize, this will merge the stack with an item already in
+	 * the list if found.
+	 * 
+	 * @param option stacktype option
+	 */
+	public void addStorage(StackType option); // adds a stack as stored
+
+	/**
+	 * add a stack to the list as craftable, this will merge the stack with an item already in the list if found.
+	 * 
+	 * @param option stacktype option
+	 */
+	public void addCrafting(StackType option);
+
+	/**
+	 * add a stack to the list, stack size is used to add to requestable, this will merge the stack with an item already
+	 * in the list if found.
+	 * 
+	 * @param option stacktype option
+	 */
+	public void addRequestable(StackType option); // adds a stack as requestable
+
+	/**
+	 * @return the first item in the list
+	 */
+	StackType getFirstItem();
+
+	/**
+	 * @return the number of items in the list
+	 */
+	int size();
+
+	/**
+	 * allows you to iterate the list.
+	 */
+	@Override
+	public Iterator<StackType> iterator();
+
+	/**
+	 * resets stack sizes to 0.
+	 */
+	void resetStatus();
+
+}

--- a/src/api/java/appeng/api/util/AECableType.java
+++ b/src/api/java/appeng/api/util/AECableType.java
@@ -1,0 +1,53 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.util;
+
+public enum AECableType
+{
+	/**
+	 * No Cable present.
+	 */
+	NONE,
+
+	/**
+	 * Connections to this block should render as glass.
+	 */
+	GLASS,
+
+	/**
+	 * Connections to this block should render as covered.
+	 */
+	COVERED,
+
+	/**
+	 * Connections to this block should render as smart.
+	 */
+	SMART,
+
+	/**
+	 * Dense Cable, represents a tier 2 block that can carry 32 channels.
+	 */
+	DENSE,
+
+}

--- a/src/api/java/appeng/api/util/AEColor.java
+++ b/src/api/java/appeng/api/util/AEColor.java
@@ -1,0 +1,111 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.util;
+
+import net.minecraft.util.StatCollector;
+
+/**
+ * List of all colors supported by AE, their names, and various colors for display.
+ * 
+ * Should be the same order as Dyes, excluding Transparent.
+ */
+public enum AEColor
+{
+
+	White("gui.appliedenergistics2.White", 0xBEBEBE, 0xDBDBDB, 0xFAFAFA),
+
+	Orange("gui.appliedenergistics2.Orange", 0xF99739, 0xFAAE44, 0xF4DEC3),
+
+	Magenta("gui.appliedenergistics2.Magenta", 0x821E82, 0xB82AB8, 0xC598C8),
+
+	LightBlue("gui.appliedenergistics2.LightBlue", 0x628DCB, 0x82ACE7, 0xD8F6FF),
+
+	Yellow("gui.appliedenergistics2.Yellow", 0xFFF7AA, 0xF8FF4A, 0xFFFFE8),
+
+	Lime("gui.appliedenergistics2.Lime", 0x7CFF4A, 0xBBFF51, 0xE7F7D7),
+
+	Pink("gui.appliedenergistics2.Pink", 0xDC8DB5, 0xF8B5D7, 0xF7DEEB),
+
+	Gray("gui.appliedenergistics2.Gray", 0x7C7C7C, 0xA0A0A0, 0xC9C9C9),
+
+	LightGray("gui.appliedenergistics2.LightGray", 0x9D9D9D, 0xCDCDCD, 0xEFEFEF),
+
+	Cyan("gui.appliedenergistics2.Cyan", 0x2F9BA5, 0x51AAC6, 0xAEDDF4),
+
+	Purple("gui.appliedenergistics2.Purple", 0x8230B2, 0xA453CE, 0xC7A3CC),
+
+	Blue("gui.appliedenergistics2.Blue", 0x2D29A0, 0x514AFF, 0xDDE6FF),
+
+	Brown("gui.appliedenergistics2.Brown", 0x724E35, 0xB7967F, 0xE0D2C8),
+
+	Green("gui.appliedenergistics2.Green", 0x45A021, 0x60E32E, 0xE3F2E3),
+
+	Red("gui.appliedenergistics2.Red", 0xA50029, 0xFF003C, 0xFFE6ED),
+
+	Black("gui.appliedenergistics2.Black", 0x2B2B2B, 0x565656, 0x848484),
+
+	Transparent("gui.appliedenergistics2.Fluix", 0x1B2344, 0x895CA8, 0xD7BBEC);
+
+	/**
+	 * Unlocalized name for color.
+	 */
+	final public String unlocalizedName;
+
+	/**
+	 * Darkest Variant of the color, nearly black; as a RGB HEX Integer
+	 */
+	final public int blackVariant;
+
+	/**
+	 * The Variant of the color that is used to represent the color normally; as a RGB HEX Integer
+	 */
+	final public int mediumVariant;
+
+	/**
+	 * Lightest Variant of the color, nearly white; as a RGB HEX Integer
+	 */
+	final public int whiteVariant;
+
+	AEColor(String unlocalizedName, int blackHex, int medHex, int whiteHex) {
+		this.unlocalizedName = unlocalizedName;
+		blackVariant = blackHex;
+		mediumVariant = medHex;
+		whiteVariant = whiteHex;
+	}
+
+	/**
+	 * Logic to see which colors match each other.. special handle for Transparent
+	 */
+	public boolean matches(AEColor color)
+	{
+		return equals(Transparent) || color.equals(Transparent) || equals(color);
+	}
+
+	@Override
+	public String toString()
+	{
+		return StatCollector.translateToLocal( unlocalizedName );
+	}
+
+}

--- a/src/api/java/appeng/api/util/AEColoredItemDefinition.java
+++ b/src/api/java/appeng/api/util/AEColoredItemDefinition.java
@@ -1,0 +1,70 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.util;
+
+import net.minecraft.block.Block;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+
+public interface AEColoredItemDefinition
+{
+
+	/**
+	 * @return the {@link Block} Implementation if applicable
+	 */
+	Block block(AEColor color);
+
+	/**
+	 * @return the {@link Item} Implementation if applicable
+	 */
+	Item item(AEColor color);
+
+	/**
+	 * @return the {@link TileEntity} Class if applicable.
+	 */
+	Class<? extends TileEntity> entity(AEColor color);
+
+	/**
+	 * @return an {@link ItemStack} with specified quantity of this item.
+	 */
+	ItemStack stack(AEColor color, int stackSize);
+
+	/**
+	 * @param stackSize
+	 *            - stack size of the result.
+	 * @return an array of all colors.
+	 */
+	ItemStack[] allStacks(int stackSize);
+
+	/**
+	 * Compare {@link ItemStack} with this {@link AEItemDefinition}
+	 *
+	 * @param color compared color of item
+	 * @param comparableItem compared item
+	 * @return true if the item stack is a matching item.
+	 */
+	boolean sameAs(AEColor color, ItemStack comparableItem);
+
+}

--- a/src/api/java/appeng/api/util/AEItemDefinition.java
+++ b/src/api/java/appeng/api/util/AEItemDefinition.java
@@ -1,0 +1,77 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.util;
+
+import net.minecraft.block.Block;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.IBlockAccess;
+
+/**
+ * Gives easy access to different part of the various, items/blocks/materials in AE.
+ */
+public interface AEItemDefinition
+{
+
+	/**
+	 * @return the {@link Block} Implementation if applicable
+	 */
+	Block block();
+
+	/**
+	 * @return the {@link Item} Implementation if applicable
+	 */
+	Item item();
+
+	/**
+	 * @return the {@link TileEntity} Class if applicable.
+	 */
+	Class<? extends TileEntity> entity();
+
+	/**
+	 * @return an {@link ItemStack} with specified quantity of this item.
+	 */
+	ItemStack stack(int stackSize);
+
+	/**
+	 * Compare {@link ItemStack} with this {@link AEItemDefinition}
+	 * 
+	 * @param comparableItem compared item
+	 * @return true if the item stack is a matching item.
+	 */
+	boolean sameAsStack(ItemStack comparableItem);
+
+	/**
+	 * Compare Block with world.
+	 * 
+	 * @param world world of block
+	 * @param x x pos of block
+	 * @param y y pos of block
+	 * @param z z pos of block
+	 * 
+	 * @return if the block is placed in the world at the specific location.
+	 */
+	boolean sameAsBlock(IBlockAccess world, int x, int y, int z);
+}

--- a/src/api/java/appeng/api/util/DimensionalCoord.java
+++ b/src/api/java/appeng/api/util/DimensionalCoord.java
@@ -1,0 +1,94 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.util;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+
+/**
+ * Represents a location in the Minecraft Universe
+ */
+public class DimensionalCoord extends WorldCoord
+{
+
+	private final World w;
+	private final int dimId;
+
+	public DimensionalCoord(DimensionalCoord s) {
+		super( s.x, s.y, s.z );
+		w = s.w;
+		dimId = s.dimId;
+	}
+
+	public DimensionalCoord(TileEntity s) {
+		super( s );
+		w = s.getWorldObj();
+		dimId = w.provider.dimensionId;
+	}
+
+	public DimensionalCoord(World _w, int _x, int _y, int _z) {
+		super( _x, _y, _z );
+		w = _w;
+		dimId = _w.provider.dimensionId;
+	}
+
+	@Override
+	public DimensionalCoord copy()
+	{
+		return new DimensionalCoord( this );
+	}
+
+	public boolean isEqual(DimensionalCoord c)
+	{
+		return x == c.x && y == c.y && z == c.z && c.w == this.w;
+	}
+
+	@Override
+	public boolean equals(Object obj)
+	{
+		return obj instanceof DimensionalCoord && isEqual((DimensionalCoord) obj);
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return super.hashCode() ^ dimId;
+	}
+
+	public boolean isInWorld(World world)
+	{
+		return w == world;
+	}
+
+	@Override
+	public String toString()
+	{
+		return dimId + "," + super.toString();
+	}
+
+	public World getWorld()
+	{
+		return w;
+	}
+}

--- a/src/api/java/appeng/api/util/IConfigManager.java
+++ b/src/api/java/appeng/api/util/IConfigManager.java
@@ -1,0 +1,84 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.util;
+
+import net.minecraft.nbt.NBTTagCompound;
+
+import java.util.Set;
+
+/**
+ * Used to adjust settings on an object,
+ * 
+ * Obtained via {@link IConfigurableObject}
+ */
+public interface IConfigManager
+{
+
+	/**
+	 * get a list of different settings
+	 * 
+	 * @return enum set of settings
+	 */
+	Set<Enum> getSettings();
+
+	/**
+	 * used to initialize the configuration manager, should be called for all settings.
+	 * 
+	 * @param settingName name of setting
+	 * @param defaultValue default value of setting
+	 */
+	void registerSetting(Enum settingName, Enum defaultValue);
+
+	/**
+	 * Get Value of a particular setting
+	 * 
+	 * @param settingName name of setting
+	 * @return value of setting
+	 */
+	Enum getSetting(Enum settingName);
+
+	/**
+	 * Change setting
+	 * 
+	 * @param settingName to be changed setting
+	 * @param newValue  new value for setting
+	 * @return changed setting
+	 */
+	Enum putSetting(Enum settingName, Enum newValue);
+
+	/**
+	 * write all settings to the NBT Tag so they can be read later.
+	 * 
+	 * @param dest to be written nbt tag
+	 */
+	void writeToNBT(NBTTagCompound dest);
+
+	/**
+	 * Only works after settings have been registered
+	 * 
+	 * @param src to be read nbt tag
+	 */
+	void readFromNBT(NBTTagCompound src);
+
+}

--- a/src/api/java/appeng/api/util/IOrientable.java
+++ b/src/api/java/appeng/api/util/IOrientable.java
@@ -1,0 +1,60 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.util;
+
+import net.minecraftforge.common.util.ForgeDirection;
+
+/**
+ * Nearly all of AE's Tile Entities implement IOrientable.
+ * 
+ * and it can be used to manipulate the direction of some machines, most of these orientations are purely visual.
+ * 
+ * AE also responds to Block.rotateBlock
+ */
+public interface IOrientable
+{
+
+	/**
+	 * @return true or false, if the tile rotation is meaningful, or even changeable
+	 */
+	boolean canBeRotated();
+
+	/**
+	 * @return the direction the tile is facing
+	 */
+	ForgeDirection getForward();
+
+	/**
+	 * @return the direction top of the tile
+	 */
+	ForgeDirection getUp();
+
+	/**
+	 * Update the orientation
+	 * @param Forward new forward direction
+	 * @param Up new upwards direction
+	 */
+	void setOrientation(ForgeDirection Forward, ForgeDirection Up);
+
+}

--- a/src/api/java/appeng/api/util/IReadOnlyCollection.java
+++ b/src/api/java/appeng/api/util/IReadOnlyCollection.java
@@ -1,0 +1,44 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.util;
+
+public interface IReadOnlyCollection<T> extends Iterable<T>
+{
+
+	/**
+	 * @return the objects in in the set.
+	 */
+	int size();
+
+	/**
+	 * @return true if there are objects in the set
+	 */
+	boolean isEmpty();
+
+	/**
+	 * @return return true if the object is part of the set.
+	 */
+	boolean contains(Object node);
+
+}

--- a/src/api/java/appeng/api/util/WorldCoord.java
+++ b/src/api/java/appeng/api/util/WorldCoord.java
@@ -1,0 +1,159 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2013 AlgorithmX2
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package appeng.api.util;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.ForgeDirection;
+
+/**
+ * Represents a relative coordinate, either relative to another object, or
+ * relative to the origin of a dimension.
+ */
+public class WorldCoord
+{
+
+	public int x;
+	public int y;
+	public int z;
+
+	public WorldCoord add(ForgeDirection direction, int length)
+	{
+		x += direction.offsetX * length;
+		y += direction.offsetY * length;
+		z += direction.offsetZ * length;
+		return this;
+	}
+
+	public WorldCoord subtract(ForgeDirection direction, int length)
+	{
+		x -= direction.offsetX * length;
+		y -= direction.offsetY * length;
+		z -= direction.offsetZ * length;
+		return this;
+	}
+
+	public WorldCoord add(int _x, int _y, int _z)
+	{
+		x += _x;
+		y += _y;
+		z += _z;
+		return this;
+	}
+
+	public WorldCoord subtract(int _x, int _y, int _z)
+	{
+		x -= _x;
+		y -= _y;
+		z -= _z;
+		return this;
+	}
+
+	public WorldCoord multiple(int _x, int _y, int _z)
+	{
+		x *= _x;
+		y *= _y;
+		z *= _z;
+		return this;
+	}
+
+	public WorldCoord divide(int _x, int _y, int _z)
+	{
+		x /= _x;
+		y /= _y;
+		z /= _z;
+		return this;
+	}
+
+	public WorldCoord(int _x, int _y, int _z) {
+		x = _x;
+		y = _y;
+		z = _z;
+	}
+
+	public WorldCoord(TileEntity s) {
+		this( s.xCoord, s.yCoord, s.zCoord );
+	}
+
+	/**
+	 * Will Return NULL if it's at some diagonal!
+	 */
+	public ForgeDirection directionTo(WorldCoord loc)
+	{
+		int ox = x - loc.x;
+		int oy = y - loc.y;
+		int oz = z - loc.z;
+
+		int xlen = Math.abs( ox );
+		int ylen = Math.abs( oy );
+		int zlen = Math.abs( oz );
+
+		if ( loc.isEqual( this.copy().add( ForgeDirection.EAST, xlen ) ) )
+			return ForgeDirection.EAST;
+
+		if ( loc.isEqual( this.copy().add( ForgeDirection.WEST, xlen ) ) )
+			return ForgeDirection.WEST;
+
+		if ( loc.isEqual( this.copy().add( ForgeDirection.NORTH, zlen ) ) )
+			return ForgeDirection.NORTH;
+
+		if ( loc.isEqual( this.copy().add( ForgeDirection.SOUTH, zlen ) ) )
+			return ForgeDirection.SOUTH;
+
+		if ( loc.isEqual( this.copy().add( ForgeDirection.UP, ylen ) ) )
+			return ForgeDirection.UP;
+
+		if ( loc.isEqual( this.copy().add( ForgeDirection.DOWN, ylen ) ) )
+			return ForgeDirection.DOWN;
+
+		return null;
+	}
+
+	public boolean isEqual(WorldCoord c)
+	{
+		return x == c.x && y == c.y && z == c.z;
+	}
+
+	public WorldCoord copy()
+	{
+		return new WorldCoord( x, y, z );
+	}
+
+	@Override
+	public boolean equals(Object obj)
+	{
+		return obj instanceof WorldCoord && isEqual((WorldCoord) obj);
+	}
+
+	@Override
+	public String toString()
+	{
+		return "" + x + "," + y + "," + z;
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return (y << 24) ^ x ^ z;
+	}
+}

--- a/src/main/java/openperipheral/integration/OpenPeripheralIntegration.java
+++ b/src/main/java/openperipheral/integration/OpenPeripheralIntegration.java
@@ -106,6 +106,7 @@ public class OpenPeripheralIntegration {
 		if (checkConfig(config, "tmechworks-mod")) Integration.addModule(new ModuleTMechworks());
 		if (checkConfig(config, "mfr-mod")) Integration.addModule(new ModuleMinefactoryReloaded());
 		if (checkConfig(config, "thermalexpansion-mod")) Integration.addModule(new ModuleThermalExpansion());
+		if (checkConfig(config, "ae2-mod")) Integration.addModule(new ModuleAppEng());
 
 		FMLCommonHandler.instance().bus().register(new ConfigChangeListener());
 

--- a/src/main/java/openperipheral/integration/appeng/AEItemStackMetaProvider.java
+++ b/src/main/java/openperipheral/integration/appeng/AEItemStackMetaProvider.java
@@ -1,0 +1,29 @@
+package openperipheral.integration.appeng;
+
+import openperipheral.api.helpers.ItemStackMetaProviderSimple;
+import openperipheral.integration.OpenPeripheralIntegration;
+
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+
+public class AEItemStackMetaProvider extends ItemStackMetaProviderSimple<Item> {
+	// Currently the only additional data we are interested in is whether the
+	// item is craftable by the network.
+	public static final String IS_CRAFTABLE_SUFFIX = "-IsCraftable";
+
+	@Override
+	public Object getMeta(Item target, ItemStack stack) {
+		if (stack.hasTagCompound()) {
+			NBTTagCompound nbt = stack.getTagCompound();
+			if (nbt.hasKey(OpenPeripheralIntegration.MOD_ID + IS_CRAFTABLE_SUFFIX)) { return nbt.getBoolean(OpenPeripheralIntegration.MOD_ID + IS_CRAFTABLE_SUFFIX); }
+		}
+
+		return null;
+	}
+
+	@Override
+	public String getKey() {
+		return "is_craftable";
+	}
+}

--- a/src/main/java/openperipheral/integration/appeng/AbstractGridAdapter.java
+++ b/src/main/java/openperipheral/integration/appeng/AbstractGridAdapter.java
@@ -1,0 +1,48 @@
+package openperipheral.integration.appeng;
+
+import openmods.reflection.MethodAccess;
+import openmods.reflection.ReflectionHelper;
+import openperipheral.api.IPeripheralAdapter;
+
+import appeng.api.networking.IGridNode;
+import appeng.api.networking.crafting.ICraftingGrid;
+import appeng.api.networking.energy.IEnergyGrid;
+import appeng.api.networking.storage.IStorageGrid;
+
+import net.minecraftforge.common.util.ForgeDirection;
+
+// Both the general ME Network adapter as well as the ME Interface adapter need
+// access to the IGridNode their tile entity is connected to. Extending this class
+// gives you a peripheral adapter with access to the grid.
+public abstract class AbstractGridAdapter implements IPeripheralAdapter {
+	protected final Class<?> CLASS;
+	private final MethodAccess.Function1<IGridNode, ForgeDirection> GET_GRIDNODE;
+
+	public AbstractGridAdapter(String className) {
+		CLASS = ReflectionHelper.getClass(className);
+		GET_GRIDNODE = MethodAccess.create(IGridNode.class, CLASS, ForgeDirection.class, "getGridNode");
+	}
+
+	@Override
+	public Class<?> getTargetClass() {
+		return CLASS;
+	}
+
+	// And a few helper methods to ease access to specific parts of the ME
+	// Network
+	protected IGridNode getGridNode(Object tileEntityController) {
+		return GET_GRIDNODE.call(tileEntityController, ForgeDirection.UNKNOWN);
+	}
+
+	protected IEnergyGrid getEnergyGrid(Object tileEntityController) {
+		return getGridNode(tileEntityController).getGrid().getCache(IEnergyGrid.class);
+	}
+
+	protected ICraftingGrid getCraftingGrid(Object tileEntityController) {
+		return getGridNode(tileEntityController).getGrid().getCache(ICraftingGrid.class);
+	}
+
+	protected IStorageGrid getStorageGrid(Object tileEntityController) {
+		return getGridNode(tileEntityController).getGrid().getCache(IStorageGrid.class);
+	}
+}

--- a/src/main/java/openperipheral/integration/appeng/AdapterInterface.java
+++ b/src/main/java/openperipheral/integration/appeng/AdapterInterface.java
@@ -1,0 +1,223 @@
+package openperipheral.integration.appeng;
+
+import openmods.inventory.legacy.ItemDistribution;
+import openmods.reflection.MethodAccess;
+import openmods.utils.InventoryUtils;
+import openperipheral.api.*;
+
+import appeng.api.AEApi;
+import appeng.api.config.Actionable;
+import appeng.api.networking.crafting.ICraftingCPU;
+import appeng.api.networking.crafting.ICraftingGrid;
+import appeng.api.networking.security.IActionHost;
+import appeng.api.networking.security.MachineSource;
+import appeng.api.networking.storage.IStorageGrid;
+import appeng.api.storage.IMEMonitor;
+import appeng.api.storage.data.IAEItemStack;
+
+import dan200.computercraft.api.peripheral.IComputerAccess;
+
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+
+import net.minecraftforge.common.util.ForgeDirection;
+
+import java.util.EnumSet;
+
+public class AdapterInterface extends AbstractGridAdapter implements IPeripheralAdapter {
+	private final MethodAccess.Function0<EnumSet> GET_TARGETS;
+
+	public AdapterInterface() {
+		super("appeng.tile.misc.TileInterface");
+
+		GET_TARGETS = MethodAccess.create(EnumSet.class, CLASS, "getTargets");
+	}
+
+	@Override
+	public String getSourceId() {
+		return "me_interface";
+	}
+
+	// Method using reflection to determine the side the ME Interface is
+	// currently
+	// pointing to. This is a helper method used to check whether the ME
+	// Interface
+	// is really pointing at an IInventory later on.
+	private ForgeDirection getPointedAt(Object tileEntityInterface) {
+		EnumSet<ForgeDirection> targets = GET_TARGETS.call(tileEntityInterface);
+		if (targets.size() != 1) { return null; }
+
+		return targets.iterator().next();
+	}
+
+	// Another helper method. Returns the IInventory the ME Interface is
+	// pointing
+	// at. Or null.
+	private IInventory getNeighborInventory(Object tileEntityInterface) {
+		ForgeDirection dir = getPointedAt(tileEntityInterface);
+		if (dir == null) { return null; }
+
+		TileEntity tileEntity = (TileEntity)tileEntityInterface;
+
+		return InventoryUtils.getInventory(tileEntity.getWorldObj(), tileEntity.xCoord, tileEntity.yCoord, tileEntity.zCoord, dir);
+	}
+
+	@LuaCallable(description = "Returns true when the interface is pointing at a valid inventory.", returnTypes = LuaReturnType.BOOLEAN)
+	public boolean hasValidTarget(Object tileEntityInterface) {
+		if (getNeighborInventory(tileEntityInterface) != null) { return true; }
+
+		return false;
+	}
+
+	@LuaCallable(description = "Retrieves details about the specified item from the ME Network.", returnTypes = LuaReturnType.TABLE)
+	public ItemStack getItemDetail(Object tileEntityInterface,
+			@Arg(name = "item", description = "Details of the item you are looking for: { id, [ dmg, [nbt_id]] }", type = LuaArgType.TABLE) SearchNeedle needle) {
+		// Search for the item in the storage grid and return it if found.
+		// Nothing fancy about this.
+		for (IAEItemStack stack : getStorageGrid(tileEntityInterface).getItemInventory().getStorageList()) {
+			if (needle.compareToAEStack(stack)) {
+				// We're wringing this through our nbt-hash provider so the
+				// nbt-id
+				// will get included in the result.
+				return NBTHashMetaProvider.convertStacks(stack);
+			}
+		}
+
+		return null;
+	}
+
+	@LuaCallable(description = "Requests the specified item to get crafted.")
+	public void requestCrafting(Object tileEntityInterface,
+			@Env("computer") IComputerAccess computer,
+			@Arg(name = "item", description = "Details of the item you want to craft: { id, [ dmg, [nbt_id]] }", type = LuaArgType.TABLE) SearchNeedle needle,
+			@Optionals @Arg(name = "qty", description = "The quantity of items you want to craft") Integer quantity,
+			@Arg(name = "cpu", description = "The name of the CPU you want to use") String wantedCpuName) {
+		// Get access to the crafting grid of the ME network
+		ICraftingGrid craftingGrid = getCraftingGrid(tileEntityInterface);
+
+		// If the lua code does not specify a quantity to request, we assume he
+		// meant 1
+		if (quantity == null) {
+			quantity = 1;
+		}
+
+		// By default and when passing null to submitJob the first free CPU will
+		// be used.
+		// We want to allow the lua program to choose which CPU should be used
+		// so we need
+		// to find the correct ICraftingCPU to the cpuName we got passed from
+		// lua code.
+		// If no CPU with that name exists, we will use the first free one as
+		// well.
+		// If several CPUs with the same name exist, we will use the first one
+		// of those.
+		ICraftingCPU wantedCpu = null;
+		if (wantedCpuName != null) {
+			for (ICraftingCPU cpu : craftingGrid.getCpus()) {
+				if (cpu.getName().equals(wantedCpuName)) {
+					// Found it!
+					wantedCpu = cpu;
+					break;
+				}
+			}
+		}
+
+		// First make sure the item exists in the network and is craftable
+		// Get the storage data from the grid
+		IStorageGrid storageGrid = getStorageGrid(tileEntityInterface);
+		IMEMonitor<IAEItemStack> monitor = storageGrid.getItemInventory();
+
+		// Iterate over it's contents to get the stack we're looking for
+		for (IAEItemStack stack : monitor.getStorageList()) {
+			if (stack.isCraftable() && needle.compareToAEStack(stack)) {
+				// Found it! As we don't want to manipulate the original stack
+				// we're grabbing ourselves
+				// a copy and set its quantity to the one specified by the lua
+				// code. We're doing this
+				// because we're using this stack to actually request the item
+				// from the network.
+				IAEItemStack copy = stack.copy();
+				copy.setStackSize(quantity);
+
+				// Create a new CraftingCallback. This callback is called when
+				// the network finished
+				// calculating the required items. It can do two things for us:
+				// a) It sends an event when items are missing to complete the
+				// request
+				// b) Otherwise it starts the crafting job, which itself is a
+				// CraftingRequester
+				// sending more events to the computer.
+				CraftingCallback craftingCallback = new CraftingCallback(computer, craftingGrid, monitor, (IActionHost)tileEntityInterface, wantedCpu, copy);
+
+				// We will need access to the worldObj of the ME Interface ->
+				// cast to TileEntity
+				TileEntity tileEntity = (TileEntity)tileEntityInterface;
+
+				// Tell the craftingGrid to begin calculating and to report
+				// everything to the CraftingCallback
+				craftingGrid.beginCraftingJob(tileEntity.getWorldObj(), getGridNode(tileEntityInterface).getGrid(), new MachineSource((IActionHost)tileEntityInterface), copy, craftingCallback);
+				break;
+			}
+		}
+	}
+
+	@LuaCallable(description = "Exports the specified item into the target inventory.", returnTypes = LuaReturnType.TABLE)
+	public ItemStack exportItem(Object tileEntityInterface,
+			@Arg(name = "item", description = "Details of the item you want to export", type = LuaArgType.TABLE) SearchNeedle needle,
+			@Optionals @Arg(name = "maxAmount", description = "The maximum amount of items you want to export") Integer maxAmount,
+			@Arg(name = "intoSlot", description = "The slot in the other inventory that you want to export into") Integer intoSlot) {
+
+		// We can only export an item from the network if the interface is
+		// explicitly pointing at
+		// an inventory. Abort and return nil if that's not the case.
+		if (!hasValidTarget(tileEntityInterface)) { return null; }
+
+		// If no specific target slot has been specified use the best one we can
+		// find.
+		if (intoSlot == null) {
+			intoSlot = -1;
+		}
+
+		// Get access to the network and its item storage
+		IStorageGrid storageGrid = getStorageGrid(tileEntityInterface);
+		IMEMonitor<IAEItemStack> monitor = storageGrid.getItemInventory();
+
+		// Search for the item by using the id, dmg and a hash over the nbt
+		// data; Take a look at
+		// SearchNeedle for more details.
+		for (IAEItemStack stack : monitor.getStorageList()) {
+			if (needle.compareToAEStack(stack)) {
+				// Found it!
+				// Make sure we are only requesting MaxStackSize items and more
+				// than 0
+				IAEItemStack copy = stack.copy();
+				if (maxAmount == null || maxAmount < 1 || maxAmount > copy.getItemStack().getMaxStackSize()) {
+					copy.setStackSize(copy.getItemStack().getMaxStackSize());
+				} else {
+					copy.setStackSize(maxAmount);
+				}
+
+				// Actually export the items from the ME system.
+				MachineSource machineSource = new MachineSource((IActionHost)tileEntityInterface);
+				IAEItemStack out = monitor.extractItems(copy, Actionable.MODULATE, machineSource);
+				ItemStack exportedStack = out.getItemStack().copy();
+
+				// Put the item in the neighbor inventory
+				ItemDistribution.insertItemIntoInventory(getNeighborInventory(tileEntityInterface), exportedStack, getPointedAt(tileEntityInterface).getOpposite(), intoSlot);
+
+				// If we've moved some items, but others are still remaining
+				// insert them back into the ME system.
+				if (exportedStack.stackSize > 0) {
+					monitor.injectItems(AEApi.instance().storage().createItemStack(exportedStack), Actionable.MODULATE, machineSource);
+					copy.setStackSize(copy.getStackSize() - exportedStack.stackSize);
+				}
+
+				// Return what we've actually extracted
+				return copy.getItemStack();
+			}
+		}
+
+		return null;
+	}
+}

--- a/src/main/java/openperipheral/integration/appeng/AdapterNetwork.java
+++ b/src/main/java/openperipheral/integration/appeng/AdapterNetwork.java
@@ -1,0 +1,92 @@
+package openperipheral.integration.appeng;
+
+import openperipheral.api.LuaCallable;
+import openperipheral.api.LuaReturnType;
+
+import appeng.api.networking.crafting.ICraftingCPU;
+import appeng.api.networking.crafting.ICraftingGrid;
+import appeng.api.networking.energy.IEnergyGrid;
+import appeng.api.networking.storage.IStorageGrid;
+import appeng.api.storage.data.IAEItemStack;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Lists;
+import java.util.Map;
+import java.util.List;
+
+import net.minecraft.item.ItemStack;
+
+public class AdapterNetwork extends AbstractGridAdapter {
+	public AdapterNetwork() {
+		super("appeng.api.networking.IGridHost");
+	}
+
+	@Override
+	public String getSourceId() {
+		return "me_network";
+	}
+
+	@LuaCallable(description = "Get a list of the stored and craftable items in the network.", returnTypes = LuaReturnType.TABLE)
+	public List<ItemStack> getAvailableItems(Object tileEntityController) {
+		IStorageGrid storageGrid = getStorageGrid(tileEntityController);
+		List<ItemStack> items = Lists.newArrayList();
+		for (IAEItemStack iaeItemStack : storageGrid.getItemInventory().getStorageList()) {
+			items.add(NBTHashMetaProvider.convertStacks(iaeItemStack));
+		}
+
+		return items;
+	}
+
+	// The following callables are all basic AE-Api <-> OpenPeripheral 1on1s
+	// There is not much to say about those. The "complicated" stuff can be
+	// found in the AdapterInterface class and the AE2 callbacks it's calling.
+	@LuaCallable(description = "Get the average power injection into the network", returnTypes = LuaReturnType.NUMBER)
+	public double getAvgPowerInjection(Object tileEntityController) {
+		IEnergyGrid energyGrid = getEnergyGrid(tileEntityController);
+		return energyGrid.getAvgPowerInjection();
+	}
+
+	@LuaCallable(description = "Get the average power usage of the network.", returnTypes = LuaReturnType.NUMBER)
+	public double getAvgPowerUsage(Object tileEntityController) {
+		IEnergyGrid energyGrid = getEnergyGrid(tileEntityController);
+		return energyGrid.getAvgPowerUsage();
+	}
+
+	@LuaCallable(description = "Get the idle power usage of the network.", returnTypes = LuaReturnType.NUMBER)
+	public double getIdlePowerUsage(Object tileEntityController) {
+		IEnergyGrid energyGrid = getEnergyGrid(tileEntityController);
+		return energyGrid.getIdlePowerUsage();
+	}
+
+	@LuaCallable(description = "Get the maximum stored power in the network.", returnTypes = LuaReturnType.NUMBER)
+	public double getMaxStoredPower(Object tileEntityController) {
+		IEnergyGrid energyGrid = getEnergyGrid(tileEntityController);
+		return energyGrid.getMaxStoredPower();
+	}
+
+	@LuaCallable(description = "Get the stored power in the network.", returnTypes = LuaReturnType.NUMBER)
+	public double getStoredPower(Object tileEntityController) {
+		IEnergyGrid energyGrid = getEnergyGrid(tileEntityController);
+		return energyGrid.getStoredPower();
+	}
+
+	@LuaCallable(description = "Get a list of tables representing the available CPUs in the network.", returnTypes = LuaReturnType.TABLE)
+	public List<Map<String, Object>> getCraftingCPUs(Object tileEntityController) {
+		ICraftingGrid craftingGrid = getCraftingGrid(tileEntityController);
+
+		// This is a simple Object -> Map mapping. This could be a converter,
+		// but this is
+		// good enough for now.
+		List<Map<String, Object>> cpus = Lists.newArrayList();
+		for (ICraftingCPU cpu : craftingGrid.getCpus()) {
+			Map<String, Object> cpuDetails = Maps.newHashMap();
+			cpuDetails.put("name", cpu.getName());
+			cpuDetails.put("storage", cpu.getAvailableStorage());
+			cpuDetails.put("coprocessors", cpu.getCoProcessors());
+			cpuDetails.put("busy", cpu.isBusy());
+			cpus.add(cpuDetails);
+		}
+
+		return cpus;
+	}
+}

--- a/src/main/java/openperipheral/integration/appeng/ConverterSearchNeedle.java
+++ b/src/main/java/openperipheral/integration/appeng/ConverterSearchNeedle.java
@@ -1,0 +1,41 @@
+package openperipheral.integration.appeng;
+
+import openperipheral.api.ITypeConverter;
+import openperipheral.api.ITypeConvertersRegistry;
+
+import java.util.Map;
+
+public class ConverterSearchNeedle implements ITypeConverter {
+
+	@Override
+	public Object fromLua(ITypeConvertersRegistry registry, Object obj, Class<?> expected) {
+		if (!(expected == SearchNeedle.class && obj instanceof Map)) { return null; }
+
+		Map<Object, Object> map = (Map<Object, Object>)obj;
+		Object id = map.get("id");
+		if (id == null) { return null; }
+
+		String[] parts = ((String)id).split(":", 2);
+
+		int dmg = getIntValue(map, "dmg", 0);
+
+		String nbtHash = null;
+		if (map.containsKey("nbt_id")) {
+			nbtHash = (String)map.get("nbt_id");
+		}
+
+		return new SearchNeedle((String)id, dmg, nbtHash);
+	}
+
+	@Override
+	public Object toLua(ITypeConvertersRegistry registry, Object obj) {
+		return null;
+	}
+
+	private static int getIntValue(Map<?, ?> map, String key, int _default) {
+		Object value = map.get(key);
+		if (value instanceof Number) { return ((Number)value).intValue(); }
+
+		return _default;
+	}
+}

--- a/src/main/java/openperipheral/integration/appeng/CraftingCallback.java
+++ b/src/main/java/openperipheral/integration/appeng/CraftingCallback.java
@@ -1,0 +1,140 @@
+package openperipheral.integration.appeng;
+
+import openperipheral.api.ApiAccess;
+import openperipheral.api.ITypeConvertersRegistry;
+
+import appeng.api.AEApi;
+import appeng.api.config.Actionable;
+import appeng.api.networking.crafting.ICraftingCPU;
+import appeng.api.networking.crafting.ICraftingCallback;
+import appeng.api.networking.crafting.ICraftingGrid;
+import appeng.api.networking.crafting.ICraftingJob;
+import appeng.api.networking.security.IActionHost;
+import appeng.api.networking.security.MachineSource;
+import appeng.api.storage.IMEMonitor;
+import appeng.api.storage.data.IAEItemStack;
+import appeng.api.storage.data.IItemList;
+
+import dan200.computercraft.api.peripheral.IComputerAccess;
+
+import net.minecraft.item.ItemStack;
+
+import com.google.common.collect.Lists;
+import java.util.List;
+
+public class CraftingCallback implements ICraftingCallback {
+	IComputerAccess computer;
+	IMEMonitor<IAEItemStack> monitor;
+	MachineSource source;
+	IActionHost actionHost;
+	ICraftingGrid craftingGrid;
+	ICraftingCPU wantedCpu;
+
+	Object requestedStack;
+
+	public CraftingCallback(IComputerAccess computer, ICraftingGrid craftingGrid, IMEMonitor<IAEItemStack> monitor, IActionHost actionHost, ICraftingCPU wantedCpu, IAEItemStack requestedStack) {
+		this.computer = computer;
+		this.monitor = monitor;
+		this.source = new MachineSource(actionHost);
+		this.actionHost = actionHost;
+		this.craftingGrid = craftingGrid;
+		this.wantedCpu = wantedCpu;
+
+		// As we only need the requested stack so we can pass it back to lua
+		// program we can convert it right here, right now.
+		this.requestedStack = ApiAccess.getApi(ITypeConvertersRegistry.class).toLua(NBTHashMetaProvider.convertStacks(requestedStack));
+	}
+
+	@Override
+	public void calculationComplete(ICraftingJob job) {
+		// IsSimulation is true when the job cannot be processed because items
+		// are missing, i.e.
+		// not available in the system or not recursively craftable.
+		// In that case we will send an event to the computer with the missing
+		// ingredients.
+		if (job.isSimulation()) {
+			// Prepare the list of items we will pass in the event later on
+			List<ItemStack> items = Lists.newArrayList();
+
+			// Grab the list of items from the job (this is basically the same
+			// list the
+			// ME Terminal shows when crafting an item).
+			IItemList<IAEItemStack> plan = AEApi.instance().storage().createItemList();
+			job.populatePlan(plan);
+
+			// This procedure to determine whether an item is missing is
+			// basically the same as
+			// the one used by AE2. Taken from here:
+			// https://github.com/AppliedEnergistics/Applied-Energistics-2/blob/rv2/src/main/java/appeng/container/implementations/ContainerCraftConfirm.java
+			List<ItemStack> missingItems = Lists.newArrayList();
+			for (IAEItemStack stack : plan) {
+				// "stack" is the stack + quantity we need
+
+				// "missing" will hold the quantity of items we are missing
+				IAEItemStack missing = stack.copy();
+
+				// "extract" will hold the quantity of items we can extract from
+				// the system.
+				IAEItemStack extract = stack.copy();
+
+				// Not sure why this is needed, but AE2 does it itself.
+				extract.reset();
+				extract.setStackSize(stack.getStackSize());
+
+				// Simulate the extraction, this is basically a "fast" way to
+				// check whether an item
+				// exists in the first place. And it's quantity. The idea is: if
+				// we can extract it,
+				// we can use it for crafting.
+				extract = monitor.extractItems(extract, Actionable.SIMULATE, source);
+
+				// If we could not extract the item, we are missing all of the
+				// quantity that's required.
+				// Otherwise we are only missing the difference between the two.
+				// This can be 0 if we
+				// were able to extract all of the required items.
+				if (extract == null) {
+					missing.setStackSize(stack.getStackSize());
+				} else {
+					missing.setStackSize(stack.getStackSize() - extract.getStackSize());
+				}
+
+				// So we only need to report items where we are actually missing
+				// some quantity.
+				if (missing.getStackSize() > 0) {
+					missingItems.add(NBTHashMetaProvider.convertStacks(missing));
+				}
+			}
+
+			// At this point missingItems should always have at least one
+			// element, because isSimulation would
+			// return false. But we will still validate it for good measure,
+			// maybe something else went wrong
+			// on the way.
+			// When we did we can finally send an event to the call computer
+			// telling him about the missing stuff
+			// and that we cannot proceed.
+			if (missingItems.size() > 0) {
+				// Assemble the result we're going to pass with the event. This
+				// is using OpenPeripherals
+				// Type conversion to include all the data we're used to having.
+				Object[] result = new Object[] {
+						this.requestedStack,
+						"missing_items",
+						ApiAccess.getApi(ITypeConvertersRegistry.class).toLua(missingItems)
+				};
+
+				computer.queueEvent(ModuleAppEng.CC_EVENT_STATE_CHANGED, result);
+			}
+
+			return;
+		}
+
+		// All items are available, we can start crafting now
+		// We are using our own ICraftingRequester so we can easily track the
+		// state of the job
+		// and forward events to the computer as needed.
+		CraftingRequester craftingRequester = new CraftingRequester(computer, actionHost, requestedStack);
+		craftingGrid.submitJob(job, craftingRequester, wantedCpu, false, source);
+	}
+}

--- a/src/main/java/openperipheral/integration/appeng/CraftingRequester.java
+++ b/src/main/java/openperipheral/integration/appeng/CraftingRequester.java
@@ -1,0 +1,83 @@
+package openperipheral.integration.appeng;
+
+import appeng.api.config.Actionable;
+import appeng.api.networking.IGridNode;
+import appeng.api.networking.crafting.ICraftingLink;
+import appeng.api.networking.crafting.ICraftingRequester;
+import appeng.api.networking.security.IActionHost;
+import appeng.api.storage.data.IAEItemStack;
+import appeng.api.util.AECableType;
+
+import dan200.computercraft.api.peripheral.IComputerAccess;
+
+import net.minecraftforge.common.util.ForgeDirection;
+
+import com.google.common.collect.ImmutableSet;
+
+public class CraftingRequester implements ICraftingRequester {
+	IActionHost original;
+	IComputerAccess computer;
+	Object requestedStack;
+
+	public CraftingRequester(IComputerAccess computer, IActionHost original, Object requestedStack) {
+		this.computer = computer;
+		this.original = original;
+		this.requestedStack = requestedStack;
+	}
+
+	@Override
+	// We want to put the crafted items straight back into the AE network.
+	// We could put them directly into the inventory we are pointing at, but
+	// that would introduce two problems:
+	// a) we have to care about whether there actually is an inventory.
+	// b) maybe the user does not want the items in the inventory in the first
+	// place, and if he does, he can simply extract them as soon as he received
+	// the event
+	public IAEItemStack injectCraftedItems(ICraftingLink link, IAEItemStack items, Actionable mode) {
+		return items;
+	}
+
+	// We broadcast the two possible events to the computer, nothing fancy about
+	// it.
+	// We're passing the already toLua converted itemstack we requested in the
+	// first place as an argument.
+	@Override
+	public void jobStateChange(ICraftingLink link) {
+		if (link.isCanceled()) {
+			computer.queueEvent(ModuleAppEng.CC_EVENT_STATE_CHANGED, new Object[] { requestedStack, "canceled" });
+		} else if (link.isDone()) {
+			computer.queueEvent(ModuleAppEng.CC_EVENT_STATE_CHANGED, new Object[] { requestedStack, "done" });
+		}
+	}
+
+	// This method should never be called on our instance since it's never
+	// really part of the ME grid in the first place. The only method that
+	// would get called is the one from the original version; we can safely
+	// ignore this method and just return null.
+	@Override
+	public ImmutableSet<ICraftingLink> getRequestedJobs() {
+		return null;
+	}
+
+	// The following methods are inherited by ICraftingRequester from
+	// IActionHost, so we can just forward the calls to the real thing.
+	@Override
+	public IGridNode getActionableNode() {
+		return original.getActionableNode();
+	}
+
+	@Override
+	public IGridNode getGridNode(ForgeDirection dir) {
+		return original.getGridNode(dir);
+	}
+
+	@Override
+	public AECableType getCableConnectionType(ForgeDirection dir) {
+		return original.getCableConnectionType(dir);
+	}
+
+	@Override
+	public void securityBreak() {
+		original.securityBreak();
+	}
+}

--- a/src/main/java/openperipheral/integration/appeng/ModuleAppEng.java
+++ b/src/main/java/openperipheral/integration/appeng/ModuleAppEng.java
@@ -1,17 +1,32 @@
 package openperipheral.integration.appeng;
 
-import openmods.Mods;
+import openperipheral.api.ApiAccess;
+import openperipheral.api.IAdapterRegistry;
+import openperipheral.api.IItemStackMetaBuilder;
+import openperipheral.api.ITypeConvertersRegistry;
 import openperipheral.integration.ModIntegrationModule;
 
 public class ModuleAppEng extends ModIntegrationModule {
+	public static final String CC_EVENT_STATE_CHANGED = "crafting_state";
 
 	@Override
 	public String getModId() {
-		return Mods.APPLIEDENERGISTICS;
+		// TODO: This should be openmods.Mods.APPLIEDENERGISTICS, but it
+		// currently contains the wrong modid.
+		return "appliedenergistics2";
 	}
 
 	@Override
 	public void load() {
-		// TODO reeimplement from base (new API)
+		final IAdapterRegistry adapterRegistry = ApiAccess.getApi(IAdapterRegistry.class);
+		adapterRegistry.register(new AdapterInterface());
+		adapterRegistry.register(new AdapterNetwork());
+
+		final ITypeConvertersRegistry convertersRegistry = ApiAccess.getApi(ITypeConvertersRegistry.class);
+		convertersRegistry.register(new ConverterSearchNeedle());
+
+		final IItemStackMetaBuilder metaBuilder = ApiAccess.getApi(IItemStackMetaBuilder.class);
+		metaBuilder.register(new NBTHashMetaProvider());
+		metaBuilder.register(new AEItemStackMetaProvider());
 	}
 }

--- a/src/main/java/openperipheral/integration/appeng/NBTHashMetaProvider.java
+++ b/src/main/java/openperipheral/integration/appeng/NBTHashMetaProvider.java
@@ -1,0 +1,92 @@
+package openperipheral.integration.appeng;
+
+import openmods.Log;
+import openperipheral.api.helpers.ItemStackMetaProviderSimple;
+import openperipheral.integration.OpenPeripheralIntegration;
+
+import appeng.api.storage.data.IAEItemStack;
+import appeng.api.storage.data.IAETagCompound;
+
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompressedStreamTools;
+import net.minecraft.nbt.NBTTagCompound;
+
+import org.apache.commons.codec.binary.Hex;
+
+import java.io.IOException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public class NBTHashMetaProvider extends ItemStackMetaProviderSimple<Item> {
+	private static final String SUFFIX_NBTHASH = "-NBTHash";
+
+	@Override
+	public Object getMeta(Item target, ItemStack stack) {
+		if (stack.hasTagCompound()) {
+			NBTTagCompound nbt = stack.getTagCompound();
+			if (nbt.hasKey(OpenPeripheralIntegration.MOD_ID + SUFFIX_NBTHASH)) { return nbt.getString(OpenPeripheralIntegration.MOD_ID + SUFFIX_NBTHASH); }
+		}
+
+		return null;
+	}
+
+	@Override
+	public String getKey() {
+		return "nbt_id";
+	}
+
+	// To get a unique hash id from the nbt tag we are:
+	// 1. Compressing the nbt tag to a byte-array using Minecrafts
+	// CompressedStreamTools
+	// 2. Creating a MD5 digest over the compressed data
+	// 3. And returning it as a hex-encoded String
+	public static String getNBTHash(IAETagCompound tag) {
+		String result = "00000000000000000000000000000000";
+		try {
+			byte[] compressed = CompressedStreamTools.compress(tag.getNBTTagCompoundCopy());
+			byte[] digest = MessageDigest.getInstance("MD5").digest(compressed);
+			result = new String(Hex.encodeHex(digest));
+		} catch (IOException e) {
+			Log.warn("Could not compress NBT Tag using CompressedStreamTools. Stack comparison with NBT data will not work!");
+		} catch (NoSuchAlgorithmException e) {
+			Log.warn("MD5 digest algorithm does not exist. Stack comparison with NBT data will not work!");
+		}
+		return result;
+	}
+
+	// Stacks created by this are only made for consumption by computercraft
+	// computers. They contain modified nbt data and can not be trusted in other
+	// situations.
+	public static ItemStack convertStacks(IAEItemStack aeStack) {
+		// First ask AE2 to give us the vanilla ItemStack.
+		// We're losing information by doing this and need to readd it later on.
+		ItemStack stack = aeStack.getItemStack().copy();
+
+		// We want to use OpenPeripherals ItemStack converter so we get all the
+		// extra data that is provided. But this is a one way conversion, i.e.
+		// we will not be able to request specific items from the ME Network if
+		// we don't have something to identify NBT tags without too much hassle.
+		// To get the converter to include this data on the "toLua" step we are
+		// adding the hash to the nbt tag now and let the NBTHashMetaProvider
+		// include the value in the actual return table.
+		if (aeStack.hasTagCompound()) {
+			stack.getTagCompound().setString(OpenPeripheralIntegration.MOD_ID + SUFFIX_NBTHASH, NBTHashMetaProvider.getNBTHash(aeStack.getTagCompound()));
+		}
+
+		// We are also adding additional data stored in IAEItemStack to the item
+		// stacks nbt data.
+		// This is later on being processing by the AEItemStackMetaProvider so
+		// it is included in the Object lua is receiving.
+		if (aeStack.isCraftable()) {
+			NBTTagCompound nbt = stack.getTagCompound();
+			if (nbt == null) {
+				nbt = new NBTTagCompound();
+			}
+			nbt.setBoolean(OpenPeripheralIntegration.MOD_ID + AEItemStackMetaProvider.IS_CRAFTABLE_SUFFIX, true);
+			stack.setTagCompound(nbt);
+		}
+
+		return stack;
+	}
+}

--- a/src/main/java/openperipheral/integration/appeng/SearchNeedle.java
+++ b/src/main/java/openperipheral/integration/appeng/SearchNeedle.java
@@ -1,0 +1,68 @@
+package openperipheral.integration.appeng;
+
+import appeng.api.storage.data.IAEItemStack;
+
+import cpw.mods.fml.common.registry.GameRegistry;
+
+import net.minecraft.item.Item;
+
+// SearchNeedle is a helper class meant to allow easier communication between
+// lua requesting access to a specific item from the network. It is able to
+// compare itself to an IAEItemStack, including its nbt data.
+public class SearchNeedle {
+	int meta = 0;
+	String id;
+	String nbtHash;
+	String modId;
+	String name;
+	Item item;
+	GameRegistry.UniqueIdentifier uuid;
+
+	public SearchNeedle(String id, int meta, String nbtHash) {
+		this.id = id;
+		this.meta = meta;
+		this.nbtHash = nbtHash;
+
+		// Prepare a few values for easier consumption later on
+		String[] parts = id.split(":");
+		this.modId = parts[0];
+		this.name = parts[1];
+
+		this.item = GameRegistry.findItem(modId, name);
+		this.uuid = GameRegistry.findUniqueIdentifierFor(this.item);
+	}
+
+	public SearchNeedle(String id, int meta) {
+		this(id, meta, null);
+	}
+
+	public SearchNeedle(String id) {
+		this(id, 0);
+	}
+
+	public boolean compareToAEStack(IAEItemStack hayStack) {
+		// If we cannot calculate a UUID to the item that got passed on,
+		// something is really
+		// wrong. Or the user is simply requesting an non existing item. Abort.
+		if (this.uuid == null) { return false; }
+
+		// Compare the uuids provided by the GameRegistry
+		GameRegistry.UniqueIdentifier stackUuid = GameRegistry
+				.findUniqueIdentifierFor(hayStack.getItem());
+		if (stackUuid == null
+				|| !stackUuid.toString().equals(this.uuid.toString())) { return false; }
+
+		// Compare the meta data
+		if (hayStack.getItemDamage() != this.meta) { return false; }
+
+		// Compare the nbtHash. More details about this can be found in the
+		// NBTHashMetaProvider
+		if (this.nbtHash != null && hayStack.hasTagCompound()) {
+			if (!this.nbtHash.equals(NBTHashMetaProvider.getNBTHash(hayStack
+					.getTagCompound()))) { return false; }
+		}
+
+		// Survived all checks. This must be the item we are looking for.
+		return true;
+	}
+}


### PR DESCRIPTION
So, I needed this myself and had it lying around since I implemented the AE2Peripheral. I cleaned, improved and commented the code - it should be an easy read being something like the third iteration of this. Happy to implement any changes required and to fix/improve/support this in the future.

Some random thoughts:

* Back in AE1 days it was not possible to export items having NBTs attached. This is resolved by providing a hash over the nbt data when retrieving an ItemStack from the ME Network (e.g. when using getItemDetails() and getAvailableItems()). This nbt_id can be used together with the id and meta data to export/craft a specific item.
* SearchNeedle and its converter are used for this. On the lua side: an ItemStack retrieved from the network can be used as a SearchNeedle itself, but only id and dmg are really required - nbt_id is optional as well.
* The itemstacks provided by AE2 are wrangled through the OpenPeripheral Type converters, so all the usual data like enchantments, bee stuff etc should be available.
* The methods provided by the AdapterNetwork should be available from cables etc. They only provide data and do not allow extraction or crafting. Exporting and crafting request require an ME Interface. Which needs to be pointed at an IInventory to export items.
* The state of crafting requests is reported to the computer via events and does not need to get polled.
* The crafting CPUs attached to the network and the ones which are named can be used when issueing a crafting request to prioritize a specific cpu.
* The mod id provided by openmods.Mods.APPLIEDENERGISTICS is currently wrong and should be "appliedenergistics2"
* More details can be found in the comments of each class.