### PR TITLE
Some more improvements to the AE2 integration

### DIFF
--- a/src/main/java/openperipheral/integration/appeng/AdapterGridBase.java
+++ b/src/main/java/openperipheral/integration/appeng/AdapterGridBase.java
@@ -61,13 +61,13 @@ public abstract class AdapterGridBase implements IPeripheralAdapter {
 		for (IAEItemStack stack : items)
 			if (compareToAEStack(fingerprint, stack)) return stack;
 
-		throw new IllegalArgumentException(String.format("Can't find item fingerprint %s", fingerprint));
+		return null;
 	}
 
 	protected static IAEItemStack findCraftableStack(IItemList<IAEItemStack> items, ItemFingerprint fingerprint) {
 		for (IAEItemStack stack : items)
 			if (compareToAEStack(fingerprint, stack, true)) return stack;
 
-		throw new IllegalArgumentException(String.format("Can't find craftable item fingerprint %s", fingerprint));
+		return null;
 	}
 }

--- a/src/main/java/openperipheral/integration/appeng/AdapterNetwork.java
+++ b/src/main/java/openperipheral/integration/appeng/AdapterNetwork.java
@@ -28,18 +28,26 @@ public class AdapterNetwork extends AdapterGridBase {
 		return "me_network";
 	}
 
-	@LuaCallable(description = "Get a list of the stored and craftable items in the network.", returnTypes = LuaReturnType.TABLE)
-	public List<IAEItemStack> getAvailableItems(IGridHost host) {
+	@LuaCallable(description = "Get a list of the stored and craftable items in the network with full item details.", returnTypes = LuaReturnType.TABLE)
+	public Object getAvailableItems(IGridHost host, @Optionals @Arg(name = "full", description = "Whether to provide full item information", type = LuaArgType.BOOLEAN) Boolean full) {
 		IStorageGrid storageGrid = getStorageGrid(host);
-		return Lists.newArrayList(storageGrid.getItemInventory().getStorageList());
+		if(full != null && full.booleanValue()) {
+			return Lists.newArrayList(storageGrid.getItemInventory().getStorageList());
+		} else {
+			List<ItemFingerprint> result = Lists.newArrayList();
+			for(IAEItemStack stack : storageGrid.getItemInventory().getStorageList()) {
+				result.add(new ItemFingerprint(stack.getItemStack()));
+			}
+
+			return result;
+		}
 	}
 
 	@LuaCallable(description = "Retrieves details about the specified item from the ME Network.", returnTypes = LuaReturnType.TABLE)
-	public ItemStack getItemDetail(IGridHost host,
+	public IAEItemStack getItemDetail(IGridHost host,
 			@Arg(name = "item", description = "Details of the item you are looking for: { id, [ dmg, [nbt_hash]] }", type = LuaArgType.TABLE) ItemFingerprint needle) {
 		final IItemList<IAEItemStack> items = getStorageGrid(host).getItemInventory().getStorageList();
-		final IAEItemStack stack = findStack(items, needle);
-		return stack.getItemStack();
+		return findStack(items, needle);
 	}
 
 	@LuaCallable(description = "Get the average power injection into the network", returnTypes = LuaReturnType.NUMBER)

--- a/src/main/java/openperipheral/integration/appeng/AdapterNetwork.java
+++ b/src/main/java/openperipheral/integration/appeng/AdapterNetwork.java
@@ -31,7 +31,7 @@ public class AdapterNetwork extends AdapterGridBase {
 	@LuaCallable(description = "Get a list of the stored and craftable items in the network with full item details.", returnTypes = LuaReturnType.TABLE)
 	public Object getAvailableItems(IGridHost host, @Optionals @Arg(name = "full", description = "Whether to provide full item information", type = LuaArgType.BOOLEAN) Boolean full) {
 		IStorageGrid storageGrid = getStorageGrid(host);
-		if(full != null && full.booleanValue()) {
+		if(full == Boolean.TRUE) {
 			return Lists.newArrayList(storageGrid.getItemInventory().getStorageList());
 		} else {
 			List<ItemFingerprint> result = Lists.newArrayList();

--- a/src/main/java/openperipheral/integration/appeng/ConverterAEItemStack.java
+++ b/src/main/java/openperipheral/integration/appeng/ConverterAEItemStack.java
@@ -18,20 +18,12 @@ public class ConverterAEItemStack implements ITypeConverter {
 		return null;
 	}
 
-	public static NBTTagCompound getTag(IAEItemStack stack) {
-		final IAETagCompound tag = stack.getTagCompound();
-		return tag != null? tag.getNBTTagCompoundCopy() : null;
-	}
-
 	@Override
 	public Object toLua(ITypeConvertersRegistry registry, Object obj) {
 		if (obj instanceof IAEItemStack) {
 			IAEItemStack aeStack = (IAEItemStack)obj;
-			ItemFingerprint fingerprint = new ItemFingerprint(aeStack.getItem(), aeStack.getItemDamage(), getTag(aeStack));
 
-			Map<String, Object> result = Maps.newHashMap();
-			result.put("fingerprint", fingerprint);
-			result.put("size", aeStack.getStackSize());
+			Map<String, Object> result = (Map<String, Object>)registry.toLua(aeStack.getItemStack());
 			result.put("is_craftable", aeStack.isCraftable());
 			result.put("is_fluid", aeStack.isFluid());
 			result.put("is_item", aeStack.isItem());

--- a/src/main/java/openperipheral/integration/vanilla/ConverterItemFingerprint.java
+++ b/src/main/java/openperipheral/integration/vanilla/ConverterItemFingerprint.java
@@ -23,9 +23,11 @@ public class ConverterItemFingerprint implements ITypeConverter {
 		if (!(tmp instanceof String)) return null;
 		String id = (String)tmp;
 
+		int dmg = 0;
 		tmp = map.get(TAG_DMG);
-		if (!(tmp instanceof Number)) return null;
-		int dmg = ((Number)tmp).intValue();
+		if (tmp instanceof Number) {
+			dmg = ((Number)tmp).intValue();
+		}
 
 		Object nbtHash = map.get(TAG_NBT);
 		return new ItemFingerprint(id, dmg, (String)nbtHash);

--- a/src/main/java/openperipheral/integration/vanilla/FingerprintMetaProvider.java
+++ b/src/main/java/openperipheral/integration/vanilla/FingerprintMetaProvider.java
@@ -1,0 +1,25 @@
+package openperipheral.integration.vanilla;
+
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+
+import openmods.utils.ItemUtils;
+import openperipheral.api.helpers.ItemStackMetaProviderSimple;
+
+public class FingerprintMetaProvider extends ItemStackMetaProviderSimple<Item>{
+    private static final String TAG_NBT = "nbt_hash";
+
+    @Override
+    public Object getMeta(Item target, ItemStack stack) {
+        if (stack.hasTagCompound()) {
+            return ItemUtils.getNBTHash(stack.getTagCompound());
+        }
+
+        return null;
+    }
+
+    @Override
+    public String getKey() {
+        return TAG_NBT;
+    }
+}

--- a/src/main/java/openperipheral/integration/vanilla/ModuleVanilla.java
+++ b/src/main/java/openperipheral/integration/vanilla/ModuleVanilla.java
@@ -48,6 +48,7 @@ public class ModuleVanilla implements IIntegrationModule {
 		itemMeta.register(new FluidContainerMetaProvider());
 		itemMeta.register(new BurnTimeMetaProvider());
 		itemMeta.register(new OreDictMetaProvider());
+		itemMeta.register(new FingerprintMetaProvider());
 
 		final IEntityMetaBuilder entityMeta = ApiAccess.getApi(IEntityMetaBuilder.class);
 		entityMeta.register(new EntityBatMetaProvider());


### PR DESCRIPTION
* Removed the directional checks of the TileInterface
* Made dmg in fingerprints optional and use 0 as default
* Made the AEItemStackConverter convert the normal ItemStack first and then add its specific information to it.
* Added a FingerprintMetaProvider providing the nbt_hash directly for all ItemStacks
* getItemDetail should not crash the program if an item does not exist as there is no other way to check whether a single item exists in the system. Maybe it should be renamed to isItemAvailable?
* Fixed typo: findCpi -> findCpu, extact -> extract