### PR TITLE
Remove console spam

### DIFF
--- a/src/main/java/openperipheral/integration/mystcraft/BookMetaProvider.java
+++ b/src/main/java/openperipheral/integration/mystcraft/BookMetaProvider.java
@@ -29,7 +29,6 @@ public class BookMetaProvider extends ItemStackMetaProviderSimple<Item> {
 			if (tag != null) {
 				Map<String, Object> result = Maps.newHashMap();
 
-				Log.info("%s", tag);
 				result.put("type", isLinkbook? "link" : (isAgebook? "age" : "unknown"));
 				result.put("destination", tag.getString("agename"));
 				result.put("dimension", tag.getInteger("Dimension"));


### PR DESCRIPTION
*This commit has been untested for compilation errors or bugs*

It appears BookMetaProvider is causing excessive console spam by reporting the NBT data of MystCraft linking books that it handles. Screenshot: http://i.imgur.com/gNprjfr.png